### PR TITLE
Project code audit

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,79 @@ const configorama = require('./src')
 const { makeBox } = require('@davidwells/box-logger')
 const getValueAtPath = require('./src/utils/parsing/getValueAtPath')
 
+function handleProcessingError(error) {
+  const errorMsg = makeBox({
+    title: `Error Processing Configuration: ${inputFile}`,
+    minWidth: '100%',
+    content: error.message,
+    type: 'error',
+  })
+  console.log(errorMsg)
+  if (argv.debug) {
+    console.error('error', error)
+  }
+  process.exit(1)
+}
+
+function getMissingRequiredEnvVars(uniqueVariables = {}) {
+  const missingVars = new Set()
+
+  Object.values(uniqueVariables).forEach((varData) => {
+    if (!varData || varData.variableType !== 'env') {
+      return
+    }
+    const occurrences = Array.isArray(varData.occurrences) ? varData.occurrences : []
+    const isRequired = occurrences.some((occurrence) => occurrence && occurrence.isRequired)
+    if (!isRequired) {
+      return
+    }
+    const envName = String(varData.variable || '').replace(/^env:/, '').trim()
+    if (envName && process.env[envName] === undefined) {
+      missingVars.add(envName)
+    }
+  })
+
+  return [...missingVars].sort()
+}
+
+function getMissingFileRefs(fileDependencies = {}) {
+  const refs = Array.isArray(fileDependencies.byConfigPath) ? fileDependencies.byConfigPath : []
+  return refs.filter((ref) => ref && ref.exists === false)
+}
+
+function printVerifySummary(analysis = {}) {
+  const summary = analysis.summary || {}
+  const totalVariables = summary.totalVariables || 0
+  const missingFileRefs = getMissingFileRefs(analysis.fileDependencies || {})
+  const missingEnvVars = getMissingRequiredEnvVars(analysis.uniqueVariables || {})
+
+  console.log('OK: Config structure is valid')
+  console.log(`OK: Found ${totalVariables} variable${totalVariables === 1 ? '' : 's'}`)
+  console.log('OK: No circular dependency check failures detected during analysis')
+
+  if (missingFileRefs.length > 0) {
+    console.log(`ERROR: Missing file references (${missingFileRefs.length})`)
+    missingFileRefs.forEach((ref) => {
+      const locationText = ref.location ? ` at ${ref.location}` : ''
+      const relativePath = ref.relativePath || ref.filePath || 'unknown path'
+      console.log(`  - ${relativePath}${locationText}`)
+    })
+  } else {
+    console.log('OK: All file references exist')
+  }
+
+  if (missingEnvVars.length > 0) {
+    console.log(`WARN: ${missingEnvVars.length} required environment variable${missingEnvVars.length === 1 ? '' : 's'} not set`)
+    missingEnvVars.forEach((name) => {
+      console.log(`  - ${name}`)
+    })
+  } else {
+    console.log('OK: All required environment variables are set or have defaults')
+  }
+
+  return missingFileRefs.length === 0
+}
+
 // Parse command line arguments
 const argv = minimist(process.argv.slice(2), {
   string: ['output', 'o', 'format', 'f', 'param'],
@@ -162,6 +235,16 @@ if (argv._.length) {
 // Set -- flags as options
 options.options = rest
 
+if (argv.verify) {
+  configorama.analyze(inputFile, options)
+    .then((analysis) => {
+      const verified = printVerifySummary(analysis)
+      process.exit(verified ? 0 : 1)
+    })
+    .catch(handleProcessingError)
+  return
+}
+
 // Process the configuration
 configorama(inputFile, options)
   .then((config) => {
@@ -218,16 +301,4 @@ configorama(inputFile, options)
       }
     }
   })
-  .catch((error) => {
-    const errorMsg = makeBox({
-      title: `Error Processing Configuration: ${inputFile}`,
-      minWidth: '100%',
-      content: error.message,
-      type: 'error',
-    })
-    console.log(errorMsg)
-    if (argv.debug) {
-      console.error('error', error)
-    }
-    process.exit(1)
-  })
+  .catch(handleProcessingError)

--- a/cli.js
+++ b/cli.js
@@ -9,6 +9,11 @@ const configorama = require('./src')
 const { makeBox } = require('@davidwells/box-logger')
 const getValueAtPath = require('./src/utils/parsing/getValueAtPath')
 
+/**
+ * Print a formatted processing error and exit
+ * @param {Error} error
+ * @returns {void}
+ */
 function handleProcessingError(error) {
   const errorMsg = makeBox({
     title: `Error Processing Configuration: ${inputFile}`,
@@ -23,6 +28,11 @@ function handleProcessingError(error) {
   process.exit(1)
 }
 
+/**
+ * Return required env vars that are currently missing
+ * @param {Record<string, { variableType?: string, variable?: string, occurrences?: Array<{ isRequired?: boolean }> }>} [uniqueVariables]
+ * @returns {string[]}
+ */
 function getMissingRequiredEnvVars(uniqueVariables = {}) {
   const missingVars = new Set()
 
@@ -44,11 +54,21 @@ function getMissingRequiredEnvVars(uniqueVariables = {}) {
   return [...missingVars].sort()
 }
 
+/**
+ * Return file references that do not currently exist
+ * @param {{ byConfigPath?: Array<{ exists?: boolean }> }} [fileDependencies]
+ * @returns {Array<{ exists?: boolean }>}
+ */
 function getMissingFileRefs(fileDependencies = {}) {
   const refs = Array.isArray(fileDependencies.byConfigPath) ? fileDependencies.byConfigPath : []
   return refs.filter((ref) => ref && ref.exists === false)
 }
 
+/**
+ * Print CLI verify summary and return verification status
+ * @param {{ summary?: { totalVariables?: number }, fileDependencies?: object, uniqueVariables?: object }} [analysis]
+ * @returns {boolean}
+ */
 function printVerifySummary(analysis = {}) {
   const summary = analysis.summary || {}
   const totalVariables = summary.totalVariables || 0

--- a/src/utils/paths/filePathUtils.js
+++ b/src/utils/paths/filePathUtils.js
@@ -1,6 +1,7 @@
 // Utilities for parsing and normalizing file paths in variable references
 
 const { splitCsv } = require('../strings/splitCsv')
+const { extractVariableWrapper } = require('../variables/variableUtils')
 
 /**
  * Normalize a file path (add ./ prefix, fix .//, skip deep refs)
@@ -118,10 +119,19 @@ function resolveInnerVariables(str, variableSyntax, config, getProp) {
     return { resolved: str, didResolve: false }
   }
 
+  const { prefix: varPrefix, suffix: varSuffix } = variableSyntax && variableSyntax.source
+    ? extractVariableWrapper(variableSyntax.source)
+    : { prefix: '${', suffix: '}' }
+
   let canResolve = true
   let resolved = str
   for (const varMatch of varMatches) {
-    const innerVar = varMatch.slice(2, -1) // Remove ${ and }
+    if (!varMatch.startsWith(varPrefix) || !varMatch.endsWith(varSuffix)) {
+      canResolve = false
+      break
+    }
+
+    const innerVar = varMatch.slice(varPrefix.length, -varSuffix.length)
     let configPath = null
 
     // Handle self: prefix

--- a/src/utils/paths/filePathUtils.test.js
+++ b/src/utils/paths/filePathUtils.test.js
@@ -227,4 +227,20 @@ test('resolveInnerVariables - partial resolution fails completely', () => {
   assert.is(result.didResolve, false)
 })
 
+test('resolveInnerVariables - supports custom {{ }} syntax wrappers', () => {
+  const config = { stage: 'prod' }
+  const customSyntax = /\{\{([^}]+)\}\}/g
+  const result = resolveInnerVariables('./config-{{self:stage}}.json', customSyntax, config, getProp)
+  assert.is(result.resolved, './config-prod.json')
+  assert.is(result.didResolve, true)
+})
+
+test('resolveInnerVariables - supports Terraform style $[ ] syntax wrappers', () => {
+  const config = { stage: 'prod' }
+  const terraformSyntax = /\$\[([^\]]+)\]/g
+  const result = resolveInnerVariables('./config-$[self:stage].json', terraformSyntax, config, getProp)
+  assert.is(result.resolved, './config-prod.json')
+  assert.is(result.didResolve, true)
+})
+
 test.run()

--- a/src/utils/resolution/preResolveVariable.js
+++ b/src/utils/resolution/preResolveVariable.js
@@ -5,6 +5,7 @@
 const fs = require('fs')
 const path = require('path')
 const dotProp = require('dot-prop')
+const { extractVariableWrapper } = require('../variables/variableUtils')
 
 const createGitResolver = require('../../resolvers/valueFromGit')
 const { parseFileContents } = require('../../resolvers/valueFromFile')
@@ -159,8 +160,19 @@ async function preResolveString(str, context, options = {}) {
   const { formatArrays = true } = options
   const { variableSyntax } = context
 
+  const { prefix: varPrefix, suffix: varSuffix } = variableSyntax && variableSyntax.source
+    ? extractVariableWrapper(variableSyntax.source)
+    : { prefix: '${', suffix: '}' }
+
   // Use provided syntax or fallback to basic pattern
-  const varPattern = variableSyntax ? new RegExp(variableSyntax.source, 'g') : /\$\{([^{}]+)\}/g
+  const varPattern = variableSyntax
+    ? new RegExp(
+        variableSyntax.source,
+        variableSyntax.flags && variableSyntax.flags.includes('g')
+          ? variableSyntax.flags
+          : `${variableSyntax.flags || ''}g`
+      )
+    : /\$\{([^{}]+)\}/g
 
   // Collect all matches first since we need async resolution
   const matches = []
@@ -173,8 +185,11 @@ async function preResolveString(str, context, options = {}) {
 
   // Resolve all matches
   const resolutions = await Promise.all(matches.map(async ({ match: matchStr }) => {
-    // Extract content between ${ and }
-    const varContent = matchStr.slice(2, -1)
+    // Extract content between wrapper prefix and suffix
+    if (!matchStr.startsWith(varPrefix) || !matchStr.endsWith(varSuffix)) {
+      return matchStr
+    }
+    const varContent = matchStr.slice(varPrefix.length, -varSuffix.length)
 
     // Skip if the content itself has ${} (nested variable)
     if (hasUnresolvedVars(varContent, variableSyntax)) {

--- a/src/utils/resolution/preResolveVariable.test.js
+++ b/src/utils/resolution/preResolveVariable.test.js
@@ -95,4 +95,20 @@ test('preResolveString - handles self: in strings', async () => {
   assert.is(result, 'Version: 1.0.0')
 })
 
+test('preResolveString - supports custom {{ }} syntax wrappers', async () => {
+  const config = { name: 'World', stage: 'prod' }
+  const customSyntax = /\{\{([\s\S]+?)\}\}/g
+  const ctx = { config, variableSyntax: customSyntax }
+  const result = await preResolveString('Hello {{name}} from {{stage}}', ctx)
+  assert.is(result, 'Hello World from prod')
+})
+
+test('preResolveString - supports Terraform style $[ ] syntax wrappers', async () => {
+  const config = { stage: 'prod' }
+  const terraformSyntax = /\$\[([\s\S]+?)\]/g
+  const ctx = { config, variableSyntax: terraformSyntax }
+  const result = await preResolveString('Stage: $[stage]', ctx)
+  assert.is(result, 'Stage: prod')
+})
+
 test.run()

--- a/tests/api/analyze.test.js
+++ b/tests/api/analyze.test.js
@@ -217,7 +217,7 @@ test('uniqueVariables groups occurrences by base variable name', async () => {
 })
 
 test('analyze serverless fixture has correct self-reference metadata', async () => {
-  const configFile = path.join(__dirname, '../_fixtures/serverless.yml')
+  const configFile = path.join(__dirname, 'serverless-analyze.yml')
 
   const result = await configorama.analyze(configFile)
 

--- a/tests/api/serverless-analyze.yml
+++ b/tests/api/serverless-analyze.yml
@@ -1,0 +1,18 @@
+service: auth-service-testing
+
+provider:
+  name: aws
+  stage: ${opt:stage, 'dev'}
+
+custom:
+  cors:
+    origin: '*'
+    headers:
+      - Content-Type
+      - Authorization
+
+functions:
+  api:
+    handler: handler.api
+    cors: ${self:custom.cors}
+    name: ${self:service}

--- a/tests/pathExtraction/pathExtraction.test.js
+++ b/tests/pathExtraction/pathExtraction.test.js
@@ -6,6 +6,8 @@ const path = require('path')
 
 const CLI_PATH = path.join(__dirname, '../../cli.js')
 const CONFIG_PATH = path.join(__dirname, 'config.yml')
+const VERIFY_ENV_CONFIG_PATH = path.join(__dirname, 'verify-env.yml')
+const VERIFY_MISSING_FILE_CONFIG_PATH = path.join(__dirname, 'verify-missing-file.yml')
 
 function runCli(args) {
   const cmd = `node ${CLI_PATH} ${args}`
@@ -164,6 +166,27 @@ test('CLI path: no path returns full config', () => {
   assert.is(parsed.service, 'my-app')
   assert.ok(parsed.database)
   assert.ok(parsed.servers)
+})
+
+test('CLI verify: reports valid structure for healthy config', () => {
+  const result = runCli(`--verify ${CONFIG_PATH}`)
+  assert.is(result.exitCode, 0)
+  assert.ok(String(result.output).includes('OK: Config structure is valid'))
+  assert.ok(String(result.output).includes('OK: All file references exist'))
+})
+
+test('CLI verify: warns when required env vars are not set', () => {
+  delete process.env.VERIFY_REQUIRED_ENV
+  const result = runCli(`--verify ${VERIFY_ENV_CONFIG_PATH}`)
+  assert.is(result.exitCode, 0)
+  assert.ok(String(result.output).includes('WARN: 1 required environment variable not set'))
+  assert.ok(String(result.output).includes('VERIFY_REQUIRED_ENV'))
+})
+
+test('CLI verify: fails on missing file references', () => {
+  const result = runCli(`--verify ${VERIFY_MISSING_FILE_CONFIG_PATH}`)
+  assert.is(result.exitCode, 1)
+  assert.ok(String(result.output).includes('ERROR: Missing file references'))
 })
 
 test.run()

--- a/tests/pathExtraction/verify-env.yml
+++ b/tests/pathExtraction/verify-env.yml
@@ -1,0 +1,3 @@
+service: verify-test
+requiredApiKey: ${env:VERIFY_REQUIRED_ENV}
+optionalApiKey: ${env:VERIFY_OPTIONAL_ENV, "fallback-api-key"}

--- a/tests/pathExtraction/verify-missing-file.yml
+++ b/tests/pathExtraction/verify-missing-file.yml
@@ -1,0 +1,2 @@
+service: verify-test
+missingRef: ${file(./does-not-exist.yml)}


### PR DESCRIPTION
Fix `--verify` CLI flag, enable custom variable wrappers in pre-resolution, and correct a broken analyze test fixture.

The `--verify` CLI flag was effectively ignored, and hardcoded `${...}` assumptions prevented custom variable syntax from working correctly in path and metadata pre-resolution. Additionally, an analyze test referenced a missing fixture, making it non-functional.

---
<p><a href="https://cursor.com/agents?id=bc-ad534266-1ae1-4f69-a305-dada04152802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ad534266-1ae1-4f69-a305-dada04152802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

