### PR TITLE
refactor: collapse duplicated parser loaders and cron interval blocks

### DIFF
--- a/src/parsers/esm.js
+++ b/src/parsers/esm.js
@@ -7,22 +7,7 @@ const path = require('path')
  * @returns {Promise<*>} The result of executing the ESM file
  */
 async function executeESMFile(filePath, opts = {}) {
-  try {
-    // Use require for now since ESM dynamic import in async context is complex
-    // We'll use jiti to handle ESM syntax
-    const { createJiti } = require('jiti')
-    const jiti = createJiti(__filename, {
-      interopDefault: true
-    })
-
-    // Load the ESM file - resolve to absolute path first
-    const resolvedPath = path.resolve(filePath)
-    let esmModule = jiti(resolvedPath)
-
-    return esmModule
-  } catch (err) {
-    throw new Error(`Failed to load ESM file ${filePath}: ${err.message}`)
-  }
+  return executeESMFileSync(filePath, opts)
 }
 
 /**

--- a/src/parsers/typescript.js
+++ b/src/parsers/typescript.js
@@ -8,54 +8,7 @@ const fs = require('fs')
  * @returns {Promise<*>} The exported module from the TypeScript file
  */
 async function executeTypeScriptFile(filePath, opts = {}) {
-  // Check if tsx is available first (preferred)
-  let useTsx = false
-  try {
-    require.resolve('tsx/cjs/api')
-    useTsx = true
-  } catch (err) {
-    // Fallback to ts-node if tsx is not available
-    try {
-      require.resolve('ts-node/register')
-    } catch (tsNodeErr) {
-      throw new Error(
-        'TypeScript support requires either "tsx" or "ts-node" to be installed. ' +
-        'Please install one of them:\n' +
-        '  npm install tsx --save-dev (recommended)\n' +
-        '  npm install ts-node typescript --save-dev'
-      )
-    }
-  }
-
-  // Clear require cache to ensure fresh execution
-  const resolvedPath = require.resolve(filePath)
-  delete require.cache[resolvedPath]
-
-  let tsFile
-  if (useTsx) {
-    // Use tsx for modern, fast TypeScript execution
-    // @ts-ignore - tsx doesn't have type declarations
-    const { register } = require('tsx/cjs/api')
-    const restore = register()
-    try {
-      tsFile = require(filePath)
-    } catch (err) {
-      throw new Error(`Failed to load TypeScript file: ${err.message}`)
-    } finally {
-      restore()
-    }
-  } else {
-    // Fallback to ts-node
-    try {
-      // @ts-ignore - ts-node is optional peer dependency
-      require('ts-node/register')
-      tsFile = require(filePath)
-    } catch (err) {
-      throw new Error(`Failed to load TypeScript file with ts-node: ${err.message}`)
-    }
-  }
-
-  return tsFile
+  return executeTypeScriptFileSync(filePath, opts)
 }
 
 /**

--- a/src/resolvers/valueFromCron.js
+++ b/src/resolvers/valueFromCron.js
@@ -91,34 +91,13 @@ function parseCronExpression(input) {
     return `${minute} ${hour} * * *`
   }
 
-  // Parse "every X minutes/hours/days" patterns
-  const everyMatch = normalizedInput.match(/^every (\d+) (minute|minutes|hour|hours|day|days|week|weeks|month|months)s?$/i)
-  if (everyMatch) {
-    const interval = parseInt(everyMatch[1])
-    const unit = everyMatch[2].toLowerCase().replace(/s$/, '') // Remove trailing 's' if present
-    
-    switch (unit) {
-      case 'minute':
-        return `*/${interval} * * * *`
-      case 'hour':
-        return `0 */${interval} * * *`
-      case 'day':
-        return `0 0 */${interval} * *`
-      case 'week':
-        return `0 0 * * 0/${interval}`
-      case 'month':
-        return `0 0 1 */${interval} *`
-      default:
-        throw new Error(`Unsupported interval unit: ${unit}`)
-    }
-  }
-
-  // Parse "X minute(s)/hour(s)/day(s)" patterns (e.g., "1 minute", "5 minutes", "1 hour")
-  const intervalMatch = normalizedInput.match(/^(\d+) (minute|minutes|hour|hours|day|days|week|weeks|month|months)s?$/i)
+  // Parse "every X minutes/hours/days" and bare "X minute(s)/hour(s)/day(s)" patterns
+  // (e.g., "every 5 minutes", "1 minute", "5 minutes", "1 hour")
+  const intervalMatch = normalizedInput.match(/^(?:every )?(\d+) (minute|minutes|hour|hours|day|days|week|weeks|month|months)s?$/i)
   if (intervalMatch) {
     const interval = parseInt(intervalMatch[1])
     const unit = intervalMatch[2].toLowerCase().replace(/s$/, '') // Remove trailing 's' if present
-    
+
     switch (unit) {
       case 'minute':
         return `*/${interval} * * * *`


### PR DESCRIPTION
## What

Behavior-preserving (isomorphic) simplification. No functional changes — pure dedup.

- **parsers**: collapse async loaders onto their sync twins (`esm.js`, `typescript.js`) — async versions now delegate instead of repeating logic
- **cron**: merge identical `every-X` and bare-`X` interval blocks in `valueFromCron.js`

Net: 6 insertions, 89 deletions across 3 files.

## Testing

- `npm test` → 1067 passed, 2 skipped, 0 failed
- `tsc --noEmit` → clean