### PR TITLE
fix(fn-sub): resolve configorama refs inside Fn::Sub, keep self/CFN verbatim

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -372,7 +372,10 @@ class Configorama {
         description: `Resolves values from files. Supports sub-properties via :key or .key lookup.`,
         match: fileRefSyntax,
         resolver: (varString, o, x, pathValue) => {
-          return this.getValueFromFile(varString, { context: pathValue })
+          // Inside ignore-path contexts (e.g. Fn::Sub) inline the file as raw text so
+          // embedded CloudFormation refs survive and the body stays a string.
+          const asRawText = !!(pathValue && this.isIgnorePath(pathValue.path))
+          return this.getValueFromFile(varString, { asRawText, context: pathValue })
         },
       },
 
@@ -483,6 +486,16 @@ class Configorama {
         .map((v) => v.match))
     )
     this.variablesKnownTypes = variablesKnownTypes
+
+    // Explicit configorama types that should still resolve inside ignore-path
+    // contexts like Fn::Sub (file, text, env, opt, cron, git, user sources, ...).
+    // Excludes self/dot.prop refs — those are left verbatim for CloudFormation /
+    // downstream Serverless resolution.
+    this.subResolvableTypes = combineRegexes(
+      /** @type {RegExp[]} */ (this.variableTypes
+        .filter((v) => v.type !== 'string' && v.type !== 'self' && v.type !== 'dot.prop' && v.match instanceof RegExp)
+        .map((v) => v.match))
+    )
 
     // Build prefix lookup map for O(1) type detection (perf optimization)
     this._resolverByPrefix = new Map()
@@ -1111,8 +1124,22 @@ class Configorama {
   // #######################
   // ## PROPERTY HANDLING ##
   // #######################
-  shouldSkipResolution(pathValue) {
+  isIgnorePath(pathValue) {
     return shouldIgnorePath(pathValue, this.ignorePathPatterns)
+  }
+  // True when the value has a configorama-typed token that resolves even inside an
+  // ignore-path (file/text/env/opt/cron/git/custom) — i.e. not just self/CFN refs.
+  hasSubResolvableToken(value) {
+    if (typeof value !== 'string') return false
+    const matches = this.getMatches(value)
+    if (!isArray(matches)) return false
+    return matches.some((m) => this.subResolvableTypes.test(m.variable))
+  }
+  shouldSkipResolution(pathValue, value) {
+    if (!this.isIgnorePath(pathValue)) return false
+    // Under an ignore path (Fn::Sub etc.) keep resolving configorama's own typed
+    // refs; only skip when nothing but self/CFN refs remain.
+    return !this.hasSubResolvableToken(value)
   }
 
   /**
@@ -1275,7 +1302,7 @@ class Configorama {
     /* Leave opaque paths verbatim. These often contain non-configorama
        `${...}` syntax from CloudFormation, JavaScript, shell, VTL, etc. */
     variables = variables.filter((property) => {
-      return !this.shouldSkipResolution(property.path)
+      return !this.shouldSkipResolution(property.path, property.value)
     })
     /*
     console.log(`variables at call count ${this.callCount}`, variables)
@@ -1563,7 +1590,7 @@ class Configorama {
       console.log(valueObject)
     }
     const property = valueObject.value
-    if (this.shouldSkipResolution(valueObject.path)) {
+    if (this.shouldSkipResolution(valueObject.path, property)) {
       return Promise.resolve(property)
     }
     const matches = this.getMatches(property)
@@ -2165,6 +2192,14 @@ Missing Value ${missingValue} - ${matchedString}
     const pathValue = valueObject.path
     // Cache joined path to avoid repeated array.join('.') calls
     const pathJoined = pathValue && pathValue.length ? pathValue.join('.') : null
+
+    // Inside ignore-path contexts (Fn::Sub, inline code, VTL templates, ...) only
+    // configorama's own typed refs (file/text/env/opt/cron/git/custom) resolve.
+    // Self refs, bare dot-prop refs, and CloudFormation refs are left verbatim for
+    // CloudFormation / downstream Serverless to resolve.
+    if (this.isIgnorePath(pathValue) && !this.subResolvableTypes.test(variableString)) {
+      return Promise.resolve(encodeUnknown(this.varPrefix + variableString + this.varSuffix))
+    }
 
     // Track every call to getValueFromSource for metadata
     if (this._trackCalls && pathJoined) {

--- a/src/main.js
+++ b/src/main.js
@@ -373,8 +373,10 @@ class Configorama {
         match: fileRefSyntax,
         resolver: (varString, o, x, pathValue) => {
           // Inside ignore-path contexts (e.g. Fn::Sub) inline the file as raw text so
-          // embedded CloudFormation refs survive and the body stays a string.
-          const asRawText = !!(pathValue && this.isIgnorePath(pathValue.path))
+          // embedded CloudFormation refs survive and the body stays a string. Skip
+          // raw mode when a :key/.key accessor is present — that needs a parsed value.
+          const hasAccessor = /\)\s*[:.]/.test(varString)
+          const asRawText = !!(pathValue && this.isIgnorePath(pathValue.path)) && !hasAccessor
           return this.getValueFromFile(varString, { asRawText, context: pathValue })
         },
       },
@@ -2193,13 +2195,6 @@ Missing Value ${missingValue} - ${matchedString}
     // Cache joined path to avoid repeated array.join('.') calls
     const pathJoined = pathValue && pathValue.length ? pathValue.join('.') : null
 
-    // Inside ignore-path contexts (Fn::Sub, inline code, VTL templates, ...) only
-    // configorama's own typed refs (file/text/env/opt/cron/git/custom) resolve.
-    // Self refs, bare dot-prop refs, and CloudFormation refs are left verbatim for
-    // CloudFormation / downstream Serverless to resolve.
-    if (this.isIgnorePath(pathValue) && !this.subResolvableTypes.test(variableString)) {
-      return Promise.resolve(encodeUnknown(this.varPrefix + variableString + this.varSuffix))
-    }
 
     // Track every call to getValueFromSource for metadata
     if (this._trackCalls && pathJoined) {
@@ -2352,6 +2347,14 @@ Missing Value ${missingValue} - ${matchedString}
     // console.log('found variable resolver', found)
     // console.log('resolverFunction', resolverFunction)
     /** */
+
+    // Inside ignore-path contexts (Fn::Sub, inline code, VTL templates, ...) leave
+    // self refs, bare config refs, and CloudFormation refs verbatim for CloudFormation
+    // / downstream Serverless to resolve. Everything configorama can resolve on its own
+    // (file/text/env/opt/cron/eval/git/custom/string/number) still resolves.
+    if (this.isIgnorePath(pathValue) && (!found || resolverType === 'self' || resolverType === 'dot.prop')) {
+      return Promise.resolve(encodeUnknown(this.varPrefix + variableString + this.varSuffix))
+    }
 
     if (found && resolverFunction) {
       /*

--- a/src/resolvers/valueFromFile.js
+++ b/src/resolvers/valueFromFile.js
@@ -115,7 +115,9 @@ function parseFileContents(content, filePath) {
  */
 async function getValueFromFile(ctx, variableString, options) {
   const opts = options || {}
-  const syntax = opts.asRawText ? ctx.textRefSyntax : ctx.fileRefSyntax
+  // Pick syntax from the ref keyword, not the raw-text flag, so a file() ref can
+  // also be inlined as raw text (e.g. inside an Fn::Sub) without losing its match.
+  const syntax = /^\s*text\(/.test(variableString) ? ctx.textRefSyntax : ctx.fileRefSyntax
   // console.log('From file', `"${variableString}"`)
   let matchedFileString = variableString.match(syntax)[0]
   // console.log('matchedFileString', matchedFileString)

--- a/src/utils/paths/ignorePaths.js
+++ b/src/utils/paths/ignorePaths.js
@@ -1,5 +1,6 @@
 const DEFAULT_IGNORE_PATHS = [
   '**.Fn::Sub',
+  '**.Fn::Sub.0',
   '**.Properties.Code.ZipFile',
   '**.Properties.FunctionCode',
   '**.Properties.UserData',

--- a/tests/fnSubPassthrough/fnSubPassthrough.test.js
+++ b/tests/fnSubPassthrough/fnSubPassthrough.test.js
@@ -7,7 +7,9 @@
  * config, the resolver could inline the surrounding template back into
  * itself and corrupt the `Fn::Sub` body.
  *
- * Fix: leave `Fn::Sub` string bodies verbatim.
+ * Inside an `Fn::Sub` body, configorama's own typed refs (file/text/env/opt/
+ * cron/git/custom) still resolve, while self refs and CloudFormation refs are
+ * left verbatim for CloudFormation / downstream Serverless to resolve.
  */
 
 const fs = require('fs')
@@ -436,6 +438,97 @@ resources:
   } finally {
     fs.rmSync(dir, { recursive: true, force: true })
   }
+})
+
+test('Fn::Sub: file-only body inlines raw JSON text and preserves CFN refs', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-fn-sub-file-'))
+  const configFile = path.join(dir, 'serverless.yml')
+  const dashboardFile = path.join(dir, 'dashboard.json')
+
+  try {
+    fs.writeFileSync(dashboardFile, `{
+  "widgets": [
+    {
+      "type": "text",
+      "properties": {
+        "markdown": "Region: \${AWS::Region}; Pool: \${CognitoUserPool}"
+      }
+    }
+  ]
+}
+`)
+
+    fs.writeFileSync(configFile, `resources:
+  Resources:
+    AuthDashboard:
+      Type: AWS::CloudWatch::Dashboard
+      Properties:
+        DashboardName: !Sub cognito-dashboard
+        DashboardBody: !Sub |
+          \${file(./dashboard.json)}
+`)
+
+    const result = configorama.sync(configFile)
+    const body = result.resources.Resources.AuthDashboard.Properties.DashboardBody['Fn::Sub']
+
+    assert.type(body, 'string')
+    assert.ok(body.startsWith('{\n  "widgets"'))
+    assert.ok(body.includes('"markdown": "Region: ${AWS::Region}; Pool: ${CognitoUserPool}"'))
+    assert.not.ok(body.includes('${file(./dashboard.json)}'))
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('Fn::Sub: file ref resolves while self + CFN refs in same body stay verbatim', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-fn-sub-mixed-'))
+  const configFile = path.join(dir, 'serverless.yml')
+  const dashboardFile = path.join(dir, 'dashboard.json')
+
+  try {
+    fs.writeFileSync(dashboardFile, `{ "ref": "\${AWS::Region}" }\n`)
+
+    fs.writeFileSync(configFile, `provider:
+  stage: dev
+resources:
+  Resources:
+    D:
+      Properties:
+        Body: !Sub |
+          \${file(./dashboard.json)} stage=\${self:provider.stage} api=\${ApiGatewayRestApi}
+`)
+
+    const body = configorama.sync(configFile).resources.Resources.D.Properties.Body['Fn::Sub']
+
+    // file() inlined as raw text, CFN ref inside the file preserved
+    assert.ok(body.includes('{ "ref": "${AWS::Region}" }'))
+    assert.not.ok(body.includes('${file(./dashboard.json)}'))
+    // self ref left verbatim (Serverless resolves it later), not inlined to "dev"
+    assert.ok(body.includes('stage=${self:provider.stage}'))
+    // bare CFN ref left verbatim for CloudFormation
+    assert.ok(body.includes('api=${ApiGatewayRestApi}'))
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('Fn::Sub: custom variable source resolves inside body', async () => {
+  const config = {
+    resources: {
+      Resources: {
+        D: { Properties: { Body: { 'Fn::Sub': 'token=${consul:foo} cfn=${ApiGatewayRestApi}' } } }
+      }
+    }
+  }
+  const result = await configorama(config, {
+    variableSources: [{
+      type: 'consul',
+      match: /^consul:/g,
+      resolver: (variableString) => Promise.resolve('RESOLVED')
+    }]
+  })
+  const body = result.resources.Resources.D.Properties.Body['Fn::Sub']
+  assert.is(body, 'token=RESOLVED cfn=${ApiGatewayRestApi}')
 })
 
 test.run()

--- a/tests/fnSubPassthrough/fnSubPassthrough.test.js
+++ b/tests/fnSubPassthrough/fnSubPassthrough.test.js
@@ -512,6 +512,123 @@ resources:
   }
 })
 
+test('Fn::Sub: file ref with :key accessor inlines the extracted value, not raw file', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-fn-sub-key-'))
+  const configFile = path.join(dir, 'serverless.yml')
+  try {
+    fs.writeFileSync(path.join(dir, 'data.json'), '{\n  "alpha": "A",\n  "beta": "B"\n}\n')
+    fs.writeFileSync(configFile, `resources:
+  Resources:
+    D:
+      Properties:
+        Body: !Sub |
+          \${file(./data.json):alpha}
+`)
+    const body = configorama.sync(configFile).resources.Resources.D.Properties.Body['Fn::Sub']
+    assert.is(body, 'A\n')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('Fn::Sub: missing file with fallback resolves to the fallback', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-fn-sub-fb-'))
+  const configFile = path.join(dir, 'serverless.yml')
+  try {
+    fs.writeFileSync(configFile, `resources:
+  Resources:
+    D:
+      Properties:
+        Body: !Sub |
+          \${file(./nope.json), 'FB'}
+`)
+    const body = configorama.sync(configFile).resources.Resources.D.Properties.Body['Fn::Sub']
+    assert.is(body, 'FB\n')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('Fn::Sub: env / cron / eval refs resolve inside body', async () => {
+  process.env.FN_SUB_TEST_ENV = 'ENVVAL'
+  const result = await configorama({
+    resources: { Resources: {
+      E: { Properties: { Body: { 'Fn::Sub': 'e=${env:FN_SUB_TEST_ENV} cfn=${ApiGatewayRestApi}' } } },
+      C: { Properties: { Body: { 'Fn::Sub': '${cron(every 5 minutes)}' } } },
+      V: { Properties: { Body: { 'Fn::Sub': '${eval(1 + 2)}' } } }
+    } }
+  })
+  const R = result.resources.Resources
+  assert.is(R.E.Properties.Body['Fn::Sub'], 'e=ENVVAL cfn=${ApiGatewayRestApi}')
+  assert.is(R.C.Properties.Body['Fn::Sub'], '*/5 * * * *')
+  assert.is(R.V.Properties.Body['Fn::Sub'], 3)
+  delete process.env.FN_SUB_TEST_ENV
+})
+
+test('Fn::Sub: configorama refs inside an inlined file resolve while CFN refs are preserved', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-fn-sub-inl-'))
+  const configFile = path.join(dir, 'serverless.yml')
+  try {
+    process.env.FN_SUB_INL_ENV = 'X'
+    fs.writeFileSync(path.join(dir, 'd.json'), '{ "e": "${env:FN_SUB_INL_ENV}", "r": "${AWS::Region}" }\n')
+    fs.writeFileSync(configFile, `resources:
+  Resources:
+    D:
+      Properties:
+        Body: !Sub |
+          \${file(./d.json)}
+`)
+    // Async (in-process) API so the env resolver sees env set during this test;
+    // the sync API runs in a child worker whose env is snapshotted at spawn.
+    const result = await configorama(configFile)
+    const body = result.resources.Resources.D.Properties.Body['Fn::Sub']
+    assert.ok(body.includes('"e": "X"'))
+    assert.ok(body.includes('"r": "${AWS::Region}"'))
+    delete process.env.FN_SUB_INL_ENV
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+test('Fn::Sub: list form leaves template refs verbatim and resolves the variables map', async () => {
+  const result = await configorama({
+    custom: { who: 'world' },
+    provider: { stage: 'dev' },
+    resources: { Resources: { D: { Properties: { Body: {
+      'Fn::Sub': [
+        'hi ${Foo} stage=${self:provider.stage} cfn=${ApiGatewayRestApi}',
+        { Foo: '${self:custom.who}' }
+      ]
+    } } } } }
+  })
+  const body = result.resources.Resources.D.Properties.Body['Fn::Sub']
+  // template (index 0) untouched, variables map (index 1) resolved
+  assert.is(body[0], 'hi ${Foo} stage=${self:provider.stage} cfn=${ApiGatewayRestApi}')
+  assert.is(body[1].Foo, 'world')
+})
+
+test('Fn::Sub: list form inlines a file ref in the template', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-fn-sub-list-'))
+  const configFile = path.join(dir, 'serverless.yml')
+  try {
+    fs.writeFileSync(path.join(dir, 'data.json'), '{ "k": "${AWS::Region}" }\n')
+    fs.writeFileSync(configFile, `resources:
+  Resources:
+    D:
+      Properties:
+        Body:
+          Fn::Sub:
+            - "data=\${file(./data.json)} v=\${Foo}"
+            - Foo: bar
+`)
+    const body = configorama.sync(configFile).resources.Resources.D.Properties.Body['Fn::Sub']
+    assert.is(body[0], 'data={ "k": "${AWS::Region}" }\n v=${Foo}')
+    assert.is(body[1].Foo, 'bar')
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true })
+  }
+})
+
 test('Fn::Sub: custom variable source resolves inside body', async () => {
   const config = {
     resources: {


### PR DESCRIPTION
## Problem

`${file(./dashboard.json)}` inside a CloudFormation `Fn::Sub` body leaked through **unresolved**. Serverless then resolved the file to an *object* and errored on string interpolation. Root cause: `**.Fn::Sub` was a blanket ignore-path, so configorama skipped the whole body — including its own refs.

Real-world failure: a `DashboardBody: !Sub |` pointing at a `dashboard.json` full of CFN refs.

## Behavior

Inside an `Fn::Sub` body, configorama's **own** refs now resolve, while CloudFormation's stay verbatim:

| Ref | Result |
|-----|--------|
| `${file(...)}` / `${text(...)}` | inlined as **raw text** (CFN refs inside survive, body stays a string) |
| `${file(x.json):key}` | parsed + extracted value inlined |
| `${env:}` `${opt:}` `${cron()}` `${eval()}` `${git:}` `${consul:}` (custom) | resolved |
| missing file with `, 'fallback'` | fallback resolved |
| `${self:...}` | **verbatim** (Serverless resolves later) |
| `${ApiGatewayRestApi}` / `${AWS::Region}` (bare / CFN) | **verbatim** |

Also fixes **list-form** `Fn::Sub: [ "tmpl ${Var}", { Var: ... } ]` — the template (index 0) is now treated as a Sub body while the variables map still resolves.

## How

- `valueFromFile.js` — pick file-vs-text syntax by the ref keyword, so `file()` can inline as raw text.
- `main.js` — `file()` inlines raw text inside ignore-paths (unless a `:key` accessor is present); a found-based guard leaves only self/dot-prop/CFN refs verbatim; selective leaf-skip keeps self-only/CFN-only bodies exactly as before.
- `ignorePaths.js` — add `**.Fn::Sub.0` for list-form templates.

## Tests

`tests/fnSubPassthrough/` grew from 14 → 23 cases (file-only inline, `:key` accessor, fallback, env/cron/eval, refs inside an inlined file, mixed self+CFN, custom source, both list-form cases). All 6 pre-existing self/CFN passthrough tests unchanged.

Full suite: **1077 passed**, 0 failed. `tsc --noEmit`: clean.