### PR TITLE
feat: 1Password resolver plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to configorama. Format roughly follows [Keep a Changelog](ht
 
 ## Unreleased
 
+### Added
+- **1Password plugin** at `plugins/onepassword/` resolving config values through the `op` CLI. Alias refs (`${op:npm.NPM_TOKEN}`), direct function syntax (`${op(op://vault/item/field)}`, item IDs/names, private item links), INI/dotenv key paths into secure notes, and field inference with ambiguity-is-an-error semantics (never silently prefers `notesPlain` over `password`). Marked `sensitive: true` / `risk: 'remote_secret_read'`; secrets are fetched at resolution time, never persisted or logged by the plugin. No npm dependencies — requires the `op` binary on `PATH`. Works through both async `configorama()` and `configorama.sync()`.
+- **`syncFactory` variable-source contract** in `src/sync.js`: plugins can carry a `syncFactory` path plus JSON-serializable `syncOptions`, which the sync worker rebuilds into a real resolver. The worker now also runs the `collectMetadata` loop so plugin metadata (e.g. `opReferences`) reaches `configorama.sync()` callers with `returnMetadata: true`.
+- **Bundled-plugin subpath exports**: `require('configorama/plugins/cloudformation')` and `require('configorama/plugins/onepassword')` now resolve from an installed package (previously the documented CloudFormation subpath did not work). `files` publishes `plugins/` while excluding plugin tests, examples, and nested `node_modules`.
+
+### Changed
+- `configorama.audit()` reports a specific high-severity `remote_secret_read` finding (with `sensitive: true`) for custom resolvers that self-describe as sensitive, instead of the generic `custom_extension` message. Plain custom resolvers are unchanged.
+
+### Docs
+- README gains a 1Password entry in Bundled Plugins; full plugin docs at `plugins/onepassword/README.md`.
+
 ## [0.10.0] — 2026-05-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ npx configorama inspect config.yml
   - [Functions (Experimental)](#functions-experimental)
 - [Bundled Plugins](#bundled-plugins)
   - [CloudFormation](#cloudformation)
+  - [1Password](#1password)
 - [API Reference](#api-reference)
   - [Async API](#async-api)
   - [Sync API](#sync-api)
@@ -1549,6 +1550,36 @@ Peer dependency (install separately):
 ```bash
 npm install @aws-sdk/client-cloudformation @aws-sdk/credential-providers
 ```
+
+### 1Password
+
+Resolves secret values through the [1Password CLI](https://developer.1password.com/docs/cli/) (`op`). Secrets are fetched at resolution time — never persisted, never logged.
+
+```yaml
+npmToken: ${op:npm.NPM_TOKEN}
+dbPassword: ${op:database}
+directRef: ${op(op://vault/item/field)}
+```
+
+```javascript
+const configorama = require('configorama')
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+const opResolver = createOnePasswordResolver({
+  refs: {
+    npm: 'op://production/npm-automation/notesPlain',
+    database: { item: 'database-prod', vault: 'production', field: 'password' },
+  },
+})
+
+const config = await configorama('config.yml', {
+  variableSources: [opResolver]
+})
+```
+
+Full docs: [`plugins/onepassword/README.md`](./plugins/onepassword/README.md). Covers alias refs, private item links, field inference and ambiguity rules, INI/dotenv key paths, `skipResolution`, and sync usage.
+
+No npm dependencies — requires the `op` binary on `PATH` and a signed-in CLI (or `OP_SERVICE_ACCOUNT_TOKEN`).
 
 ---
 

--- a/docs/plans/onepassword-resolver-plugin.md
+++ b/docs/plans/onepassword-resolver-plugin.md
@@ -1,0 +1,992 @@
+# 1Password resolver plugin implementation plan
+
+## Status
+
+This plan is ready for implementation. The remaining open questions from the earlier draft have been resolved with the decisions in this document.
+
+Key decisions:
+
+- Ship `plugins/onepassword` from the root `configorama` npm package and fix the existing CloudFormation plugin export at the same time.
+- Support both async `configorama()` and sync `configorama.sync()` usage.
+- Use `op read --no-newline` for `op://` secret references.
+- Allow aliases matching only `/^[A-Za-z0-9_]+$/`.
+- Allow aliases to point to an item, a field on an item, an `op://` secret reference, or a private 1Password item link.
+- Treat ambiguous 1Password item fields as errors. Do not silently prefer `notesPlain` over `password` or another concealed field.
+- Two syntaxes only: alias colon syntax and direct function syntax. Raw `op://` refs in colon syntax (`${op:op://...}`) are rejected with a pointer to `${op(op://...)}`.
+- Return the raw selected field for `${op:alias}`. Parse structured text only when the config reference asks for a key path, such as `${op:alias.NPM_TOKEN}`.
+- Reuse the root package `ini` dependency for INI/dotenv parsing if its coercion behavior passes the parser tests; hand-roll only if `ini` fights the raw-value rules.
+- No core `safetyPolicy.js` change in v1. Safe mode already blocks all custom resolvers by default (`src/main.js:232`, `src/utils/security/safetyPolicy.js:85-92`), which satisfies the blocking requirement. Only the audit report changes.
+- The no-private-URL metadata rule applies to the plugin's `opReferences` entries. Core metadata (`resolutionHistory`, `originalConfig`) captures raw variable strings from the config file and is out of scope.
+- Support 1Password private item links copied from "Copy Private Link", such as `https://start.1password.com/open/i?a=...&v=...&i=...&h=...`.
+- Do not support public "share with anyone" token links in v1.
+- Mark the plugin as sensitive and high risk in metadata/audit surfaces.
+- In safe mode, block actual resolution by default but allow inspect/audit to report the risk.
+- Add mocked unit tests first; add an optional real `op` smoke test gated by `CONFIGORAMA_OP_E2E=1`.
+
+Reference facts verified against current 1Password CLI docs:
+
+- `op read <reference>` reads a field specified by a secret reference and supports `--no-newline`.
+- `op item get <item>` supports `--format json`, `--reveal`, `--vault`, and field filtering.
+- Private item URLs use query parameters such as `v` for vault ID and `i` for item ID.
+- CLI scoping can be controlled by `--account`, `--config`, `--vault`, and environment variables such as `OP_ACCOUNT`, `OP_CONFIG_DIR`, and `OP_SERVICE_ACCOUNT_TOKEN`.
+
+Reference facts verified against the codebase:
+
+- The runtime variable regex from `buildVariableSyntax` (`src/utils/variables/variableUtils.js:104-108`) allows `&`, `?`, `=`, `/`, `(`, `)`, `:`, `.`, and spaces, so private-link URLs and spaced item names parse in `${op(...)}` syntax.
+- Function rewriting only triggers for registered function names (`src/main.js:2136-2138`), so `op(...)` is not mistaken for a config function.
+- Comma fallback splitting is parenthesis-depth aware (`src/utils/strings/splitCsv.js`), so commas inside `op(...)` do not split.
+- No built-in variable type collides with the `op:`/`op(` prefix; custom sources dispatch before the fall-through self matcher (`src/main.js:535-539`).
+
+Primary documentation links:
+
+- https://www.1password.dev/cli/reference/commands/read
+- https://www.1password.dev/cli/reference/management-commands/item
+- https://www.1password.dev/cli/secret-reference-syntax
+- https://www.1password.dev/cli/environment-variables
+
+## Goal
+
+Build an opt-in Configorama plugin under `plugins/onepassword/` that resolves configuration values from the 1Password CLI.
+
+The plugin should let config authors reference secret material without copying it into environment variables, local files, or committed config. It should preserve the same operational property as the existing shell-helper workflow: the secret is fetched at resolution time, never persisted by Configorama, never printed by the plugin, and never exported beyond the returned resolved config value.
+
+Initial target syntax:
+
+```yaml
+npmToken: ${op:npm.NPM_TOKEN}
+dbPassword: ${op:database}
+directItem: ${op(item-id-example).NPM_TOKEN}
+directSecretRef: ${op(op://vault/item/field)}
+directSecretRefKey: ${op(op://vault/item/notesPlain).NPM_TOKEN}
+privateLink: ${op(https://start.1password.com/open/i?a=acct&v=vault-id&i=item-id&h=my.1password.com).NPM_TOKEN}
+```
+
+Recommended usage should be alias based:
+
+```js
+const configorama = require('configorama')
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+const opResolver = createOnePasswordResolver({
+  refs: {
+    npm: 'op://production/npm-automation/notesPlain',
+    database: {
+      item: 'database-prod',
+      vault: 'production',
+      field: 'password'
+    },
+    github: {
+      item: 'GitHub',
+      vault: 'development',
+      section: 'credentials',
+      field: 'personal_token'
+    },
+    copiedLink: 'https://start.1password.com/open/i?a=acct&v=vault-id&i=item-id&h=my.1password.com'
+  }
+})
+
+const config = await configorama('config.yml', {
+  variableSources: [opResolver]
+})
+```
+
+## Why this belongs as a plugin
+
+1Password is a remote secret source, not a core parser feature. Keeping it in `plugins/onepassword/` matches the CloudFormation plugin pattern:
+
+- users opt in through `variableSources`
+- 1Password CLI behavior does not become a hard dependency of Configorama core
+- 1Password-specific metadata can be collected separately from local file dependencies
+- safe-mode and audit behavior can classify it as a sensitive remote resolver
+- service account, account, vault, and app-integration details stay isolated from the core resolver loop
+
+## Non-goals for v1
+
+- Do not implement 1Password Connect.
+- Do not manage service account creation, signin, or token provisioning.
+- Do not auto-run `op signin`.
+- Do not write secrets to disk.
+- Do not log CLI stdout or stderr.
+- Do not support public "share with anyone" token links.
+- Do not implement every 1Password structured note format on day one.
+- Do not create a broad schema language for selecting item fields.
+- Do not silently choose between conflicting fields.
+- Do not parse whole selected fields into objects merely because they contain `=`.
+
+`OP_SERVICE_ACCOUNT_TOKEN` may still work naturally because the 1Password CLI reads it. The plugin should document this as a CLI behavior, not as plugin-managed auth.
+
+## Package and export work
+
+The current root package docs show:
+
+```js
+require('configorama/plugins/cloudformation')
+```
+
+but the root package currently exports only:
+
+```json
+{
+  ".": "./src/index.js",
+  "./parse-file": "./src/utils/parsing/parse.js"
+}
+```
+
+and `files` does not include `plugins/`. That means the documented CloudFormation plugin subpath does not work from an installed root package.
+
+This implementation should fix plugin packaging for both bundled plugins:
+
+```json
+{
+  "exports": {
+    ".": "./src/index.js",
+    "./parse-file": "./src/utils/parsing/parse.js",
+    "./plugins/cloudformation": "./plugins/cloudformation/index.js",
+    "./plugins/onepassword": "./plugins/onepassword/index.js"
+  },
+  "files": [
+    "cli.js",
+    "src",
+    "plugins",
+    "!plugins/*/*.test.js",
+    "!plugins/*/example",
+    "!plugins/*/package-lock.json",
+    "types",
+    "index.d.ts",
+    "package.json",
+    "package-lock.json",
+    "README.md"
+  ]
+}
+```
+
+npm auto-excludes `node_modules` from the tarball. The negation patterns keep plugin tests, examples, and nested lockfiles out of the published package. Verify the final tarball contents with `npm pack --dry-run`.
+
+Do this as part of the 1Password plugin work because the public examples for bundled plugins depend on it.
+
+Keep each plugin's local `package.json` for standalone development/testing, but make root-package subpath imports the primary documented path.
+
+## Public API
+
+```js
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+const resolver = createOnePasswordResolver({
+  refs: {
+    npm: 'op://prod/npm/notesPlain',
+    db: {
+      item: 'database-prod',
+      vault: 'production',
+      field: 'password'
+    },
+    rawToken: {
+      ref: 'op://prod/npm/automation_token'
+    },
+    copiedLink: 'https://start.1password.com/open/i?a=acct&v=vault-id&i=item-id&h=my.1password.com'
+  },
+  account: 'my',
+  configDir: '/path/to/op/config',
+  skipResolution: false
+})
+```
+
+Returned variable source:
+
+```js
+{
+  type: 'op',
+  source: 'remote',
+  prefix: 'op',
+  syntax: '${op:alias.KEY}, ${op(item).KEY}, or ${op(op://vault/item/field)}',
+  description: 'Resolves values from 1Password through the op CLI',
+  sensitive: true,
+  risk: 'remote_secret_read',
+  match: /^op(?::|\()/,
+  resolver,
+  metadataKey: 'opReferences',
+  collectMetadata,
+  clearCache,
+  syncFactory: require.resolve('./sync-factory'),
+  syncOptions: serializableOptions
+}
+```
+
+`syncFactory` and `syncOptions` are new core-facing contract fields described in the sync section.
+
+## Syntax
+
+### Alias syntax
+
+```yaml
+value: ${op:alias}
+value: ${op:alias.KEY}
+value: ${op:alias.section.KEY}
+```
+
+Alias names must match:
+
+```js
+/^[A-Za-z0-9_]+$/
+```
+
+Dots are not allowed in alias names because dot separates the alias from a structured key path.
+
+`alias` is looked up in `createOnePasswordResolver({ refs })`.
+
+When a path follows the alias, the plugin first selects the backing 1Password field, parses that field as INI/dotenv in v1, then returns the nested key path.
+
+### Direct function syntax
+
+```yaml
+value: ${op(item-or-url-or-secret-ref)}
+value: ${op(item-or-url-or-secret-ref).KEY}
+```
+
+Function syntax is required for direct item names, private item URLs, and secret refs that may contain dots, slashes, spaces, query parameters, or colons. It gives the parser a reliable boundary: the item/link/ref lives inside `op(...)`, and the key path starts after `)`.
+
+Direct specs may be:
+
+- an `op://vault/item/field` secret reference
+- a 1Password item ID
+- a 1Password item name
+- a private 1Password item link copied with "Copy Private Link"
+
+Direct item names with spaces should work:
+
+```yaml
+token: ${op(My Database Login).password}
+```
+
+but documentation should recommend aliases for readability and auditability.
+
+### Unsupported syntax
+
+Reject raw `op://` refs in colon syntax with a message pointing to function syntax:
+
+```yaml
+value: ${op:op://vault/item/field}
+```
+
+Error: `Use ${op(op://vault/item/field)} for direct secret references.`
+
+Colon syntax is reserved for aliases only. Supporting raw refs after the colon would require extra parse-ambiguity rules for no capability gain — function syntax already covers direct refs.
+
+Reject raw private links in colon syntax:
+
+```yaml
+value: ${op:https://start.1password.com/open/i?...}
+```
+
+Reject public share links in all syntaxes for v1. The plugin should identify them as unsupported 1Password share links and tell users to use "Copy Private Link" or an `op://` secret reference instead.
+
+## Reference normalization
+
+Normalize every configured or direct reference into one of these forms:
+
+```js
+{ kind: 'secretRef', ref: 'op://vault/item/field' }
+{ kind: 'item', item: 'item-id-or-name', vault: undefined, section: undefined, field: undefined }
+{ kind: 'item', item: 'database-prod', vault: 'production', section: undefined, field: 'password' }
+{ kind: 'item', item: 'GitHub', vault: 'development', section: 'credentials', field: 'personal_token' }
+{ kind: 'privateLink', item: 'item-id', vault: 'vault-id' }
+```
+
+Accepted `refs` forms:
+
+```js
+refs: {
+  npm: 'op://prod/npm/notesPlain',
+  db: 'database-prod',
+  copiedLink: 'https://start.1password.com/open/i?a=acct&v=vault-id&i=item-id&h=my.1password.com',
+  github: {
+    item: 'GitHub',
+    vault: 'development',
+    section: 'credentials',
+    field: 'personal_token'
+  },
+  raw: {
+    ref: 'op://prod/item/field'
+  },
+  link: {
+    url: 'https://start.1password.com/open/i?a=acct&v=vault-id&i=item-id&h=my.1password.com'
+  }
+}
+```
+
+Validation rules:
+
+- Alias keys must match `/^[A-Za-z0-9_]+$/`.
+- A string beginning with `op://` is a secret ref.
+- A string beginning with `https://start.1password.com/open/i` or `onepassword://open/i` is a private item link.
+- A string that looks like a public share URL is rejected.
+- Any other string is treated as an item ID or item name.
+- Object refs must specify exactly one of `item`, `ref`, or `url`.
+- `section` is meaningful only with `field`.
+- If `field` is configured and multiple matching fields exist in different sections, require `section`.
+
+## Private link handling
+
+Support private item links copied from 1Password:
+
+```text
+https://start.1password.com/open/i?a=ACCOUNT&v=VAULT_ID&i=ITEM_ID&h=my.1password.com
+onepassword://open/i?a=ACCOUNT&v=VAULT_ID&i=ITEM_ID&h=my.1password.com
+```
+
+Parsing behavior:
+
+- Extract `i` as item ID.
+- Extract `v` as vault ID.
+- Ignore `a` and `h` for command construction and metadata.
+- Do not preserve the raw URL in metadata.
+- Use `op item get <itemId> --vault <vaultId> --format json --reveal`.
+
+If `i` is missing, throw an invalid private-link error.
+
+If `v` is missing, allow the fetch without `--vault`, but attach a warning-like diagnostic in metadata because service accounts and duplicated item names may require vault scoping.
+
+## CLI behavior
+
+Create a utility module:
+
+```text
+plugins/onepassword/op-cli.js
+```
+
+Responsibilities:
+
+- execute `op` with `child_process.execFile`
+- never use `exec`
+- never log stdout or stderr
+- translate missing binary errors into a useful message
+- run `op read --no-newline <ref>` for secret refs
+- run `op item get <spec> --format json --reveal` for item IDs, item names, and private links
+- pass `--vault` for explicit vaults or vault IDs extracted from private links
+- pass `--account` when configured
+- pass `--config` when `configDir` is configured
+- return parsed JSON for item fetches
+- expose dependency injection for tests
+
+Proposed API:
+
+```js
+async function runOp(args, options = {}) {}
+async function readSecretRef(ref, options = {}) {}
+async function getItem(spec, options = {}) {}
+```
+
+`runOp()` should catch and sanitize:
+
+- `ENOENT`: 1Password CLI is not installed or not on `PATH`
+- signin/auth errors: user likely needs to sign in, unlock app integration, or configure `OP_SERVICE_ACCOUNT_TOKEN`
+- not-found errors: item, vault, or field could not be found
+- JSON parse errors from `op item get --format json`
+
+Do not perform a separate `command -v op` preflight. Calling `execFile('op', ...)` and translating `ENOENT` is simpler and avoids duplicate checks.
+
+### CLI flags
+
+Secret refs:
+
+```text
+op read --no-newline op://vault/item/field
+```
+
+Item fetches:
+
+```text
+op item get <item-or-id> --format json --reveal
+op item get <item-or-id> --vault <vault> --format json --reveal
+```
+
+Global scoping:
+
+```text
+--account <account>
+--config <configDir>
+```
+
+The plugin should not pass secrets through command-line arguments except for `op://` references and item identifiers already supplied by the user in config. It must never pass resolved secret values as args.
+
+## Field selection
+
+### Explicit field selection
+
+If `field` is explicitly configured on a ref object, select that 1Password field.
+
+Match against:
+
+- `field.id`
+- `field.label`
+- `field.purpose`
+
+Matching should be case-insensitive.
+
+If multiple fields match only because they share the same label across sections, require `section`.
+
+If `section` is configured, match against:
+
+- `field.section.id`
+- `field.section.label`
+
+also case-insensitively.
+
+### Secret ref selection
+
+For `op://` refs, use `op read --no-newline`. The secret ref itself selects the field, so do not fetch the item JSON just to infer a field.
+
+If a key path is supplied after an `op://` ref, parse the returned secret value as INI/dotenv and select the key.
+
+### Inferred field selection
+
+If no `field` is configured, inspect the item JSON returned by `op item get --format json --reveal`.
+
+Collect candidate fields from `item.fields`. Include candidates likely to contain secret content:
+
+- `id`, `label`, or `purpose` equal to `notesPlain` or notes
+- `purpose` equal to `PASSWORD`
+- `type` equal to `CONCEALED`
+- labels commonly used for secret content, such as `password`, `token`, `api_key`, `api key`, `secret`, `credential`, `private key`
+
+Ignore common metadata/user fields for auto-selection:
+
+- username
+- email
+- URL/website fields
+- timestamps
+- item title
+- non-secret text fields without a secret-like label or purpose
+
+Inference rule:
+
+1. If exactly one candidate exists, use it.
+2. If multiple candidates exist, throw an ambiguity error that names candidate field labels and tells the user to configure `field` and optionally `section`.
+3. If no candidate exists, throw a no-secret-field error.
+
+Important: do not prefer `notesPlain` over `password` when both exist. That is ambiguous.
+
+## Structured value parsing
+
+Create:
+
+```text
+plugins/onepassword/parser.js
+```
+
+V1 supports INI/dotenv-style parsing only.
+
+Use the root package `ini` dependency (`ini@^5.0.0`, already in `package.json`) rather than hand-rolling a parser. Caveat to prove out in the parser tests: `ini` coerces `true`/`false` and strips quotes. If that coercion violates the raw-value rules below, wrap or replace it — decide from failing tests, not up front.
+
+Behavior:
+
+- `${op:alias}` returns the raw selected field text, even if it contains `=`.
+- `${op:alias.KEY}` parses the selected field as INI/dotenv and returns `KEY`.
+- `${op:alias.section.KEY}` parses the selected field and returns a nested section key.
+- Missing keys throw a clear key-path error.
+- Empty string values must be preserved.
+- Parser errors must not include secret values.
+
+Example selected field:
+
+```ini
+# npm automation token
+NPM_TOKEN=npm_xxx
+
+[database]
+password=s3cr3t
+```
+
+Valid references:
+
+```yaml
+npmToken: ${op:npm.NPM_TOKEN}
+dbPassword: ${op:npm.database.password}
+rawNote: ${op:npm}
+```
+
+Do not infer whole-object parsing from the presence of `=`. Tokens, base64, connection strings, and private keys can contain `=`.
+
+Shape the parser for future format support:
+
+```js
+function parseStructuredSecret(value, options = {}) {
+  return parseIni(value)
+}
+```
+
+Future parser detection can follow this order:
+
+1. explicit `format` option on the ref
+2. JSON if the trimmed value starts with `{` or `[`
+3. YAML only if there is a clear reason and tests prove it is not confused with INI
+4. INI fallback
+
+Do not add JSON/YAML support in v1 unless implementation stays small and tests are very clear.
+
+## Resolver behavior
+
+Resolution flow:
+
+1. Parse the variable string into `{ reference, keyPath }`.
+2. Resolve aliases through `refs`.
+3. Normalize the reference.
+4. Record metadata before fetching.
+5. If `skipResolution` is true, return a placeholder.
+6. Fetch the secret ref or item JSON through `op-cli`.
+7. Select or infer the field.
+8. If no key path is supplied, return the raw selected value.
+9. If a key path is supplied, parse selected value as INI/dotenv and return the key path.
+
+### Placeholders for skipResolution
+
+`skipResolution` means "collect metadata and prove the resolver recognized the reference, but do not fetch from 1Password."
+
+Return deterministic placeholders:
+
+```text
+[OP:alias:npm.NPM_TOKEN]
+[OP:secretRef:op://vault/item/field]
+[OP:item:item-id]
+[OP:item:item-id:NPM_TOKEN]
+[OP:privateLink:item-id]
+```
+
+Rules:
+
+- Never include raw private links.
+- Never include secret values.
+- Include the `op://` ref itself; it is already plain text in the user's config and distinguishes placeholders when multiple refs resolve in one run.
+- Prefer alias names when the user used alias syntax.
+- Include key path when present.
+
+## Caching
+
+Cache per resolver instance, not globally.
+
+Suggested caches:
+
+- secret ref values keyed by account/config/ref
+- item JSON keyed by account/config/vault/item
+- selected field metadata keyed by normalized reference plus field/section
+
+Cache successes only. Do not cache auth failures, not-found failures, parse failures, or ambiguity failures.
+
+Caching should never write to disk. It exists only to avoid repeated `op` calls during one Configorama resolution run.
+
+Add `clearCache()` to match the CloudFormation plugin pattern.
+
+`clearCache()` should clear:
+
+- secret ref cache
+- item JSON cache
+- field selection cache
+- collected metadata
+
+## Metadata
+
+Expose `metadataKey: 'opReferences'`.
+
+Each occurrence should record:
+
+```js
+{
+  raw: '${op:npm.NPM_TOKEN}',
+  resolved: '${op:npm.NPM_TOKEN}',
+  alias: 'npm',
+  referenceKind: 'item',
+  item: 'item-id-example',
+  vault: 'vault-id-example',
+  field: 'notesPlain',
+  section: undefined,
+  keyPath: 'NPM_TOKEN',
+  configPath: 'provider.environment.NPM_TOKEN',
+  sensitive: true,
+  risk: 'remote_secret_read',
+  source: 'remote',
+  skipped: false
+}
+```
+
+For private links:
+
+```js
+{
+  raw: '${op(copied private link).NPM_TOKEN}',
+  resolved: '${op(...).NPM_TOKEN}',
+  referenceKind: 'privateLink',
+  item: 'item-id',
+  vault: 'vault-id',
+  keyPath: 'NPM_TOKEN',
+  configPath: 'provider.environment.NPM_TOKEN',
+  sensitive: true,
+  risk: 'remote_secret_read',
+  source: 'remote'
+}
+```
+
+Do not record in `opReferences`:
+
+- secret values
+- full private item URLs
+- `a` account query parameter
+- `h` hostname query parameter
+- public share URL tokens
+- CLI stdout/stderr
+
+Scope note: these rules govern the plugin's `opReferences` entries only. Core metadata surfaces (`resolutionHistory`, `resolutionTracking`, `originalConfig`) record raw variable strings straight from the config file, so a private link written in config will appear there. That is the user's own committed config content, not a plugin leak, and scrubbing it in core is out of scope.
+
+Metadata may include diagnostics:
+
+```js
+{
+  level: 'warning',
+  code: 'op_private_link_missing_vault',
+  message: '1Password private link did not include a vault ID; service accounts and duplicate item names may require vault scoping.',
+  configPath: '...'
+}
+```
+
+## Sensitive plugin and audit behavior
+
+Mark this plugin as:
+
+```js
+{
+  source: 'remote',
+  sensitive: true,
+  risk: 'remote_secret_read'
+}
+```
+
+Core audit should learn to use these fields when present on custom resolvers:
+
+- `sensitive: true` means the resolver can return secret material.
+- `risk: 'remote_secret_read'` should produce a high-severity finding.
+- The existing generic `custom_extension` finding may still be included, but the report should prefer the more specific message when available.
+
+Recommended audit finding:
+
+```js
+{
+  id: 'customResolver:op',
+  severity: 'high',
+  risk: 'remote_secret_read',
+  kind: 'source',
+  variableType: 'op',
+  sensitive: true,
+  message: 'Custom resolver "op" reads secret values from 1Password.'
+}
+```
+
+Safe mode behavior:
+
+- During actual resolution, safe mode already blocks all custom resolvers by default (`src/main.js:232`, `src/utils/security/safetyPolicy.js:85-92`). That satisfies "block sensitive resolvers by default" with zero core change.
+- `audit`, `introspect`, and `analyze` already pass `blockCustomResolvers: false` (`src/index.js:145-162`), so the plugin can register and be reported without fetching secrets.
+- No `safetyPolicy.js` change in v1. Classifying resolvers by sensitivity inside the policy is not needed until safe mode wants to allow non-sensitive custom resolvers, which nothing requires yet.
+
+Audit changes needed:
+
+- `src/index.js:165-167` currently passes only `source.type` strings to `buildAuditReport`. Pass the source objects (or `{ type, sensitive, risk }` projections) so audit can see `sensitive` and `risk`.
+- `src/utils/introspection/audit.js:43-54` emits the generic `custom_extension` finding. When a resolver carries `risk`/`sensitive`, emit the specific high-severity finding instead.
+
+## Sync support
+
+The plugin must support both:
+
+```js
+await configorama('config.yml', {
+  variableSources: [createOnePasswordResolver(options)]
+})
+```
+
+and:
+
+```js
+configorama.sync('config.yml', {
+  variableSources: [createOnePasswordResolver(options)]
+})
+```
+
+The current sync bridge in `src/sync.js` expects custom variable sources to be serializable descriptors with:
+
+- `match` as a string
+- `resolver` as a path to a JS file
+
+That is not sufficient for a plugin factory with refs, caches, metadata, and options.
+
+Add a sync-compatible plugin contract:
+
+```js
+{
+  type: 'op',
+  match: /^op(?::|\()/,
+  resolver,
+  syncFactory: require.resolve('./sync-factory'),
+  syncOptions: {
+    refs,
+    account,
+    configDir,
+    skipResolution
+  }
+}
+```
+
+Core sync bridge behavior:
+
+1. In `src/index.js`, keep passing `_settings.variableSources` to `sync-rpc`. sync-rpc JSON-serializes the init args, so RegExp `match` arrives as `{}` and function `resolver` is dropped — `syncFactory` (string path) and `syncOptions` (JSON) survive, which is why the worker must check `syncFactory` before the existing string-descriptor validation.
+2. In `src/sync.js`, detect sources with `syncFactory`.
+3. Require the factory path inside the sync worker.
+4. Call the factory with `syncOptions`.
+5. Use the returned resolver object as a normal variable source.
+6. In the worker's `returnMetadata` block (`src/sync.js:53-77`), add the same `collectMetadata` loop that the async path runs in `src/index.js:76-88`, iterating the factory-created sources. Without this, `opReferences` never reaches sync callers.
+
+Example worker code shape:
+
+```js
+if (varSrc.syncFactory) {
+  const createSource = require(getFullPath(varSrc.syncFactory))
+  const source = createSource(varSrc.syncOptions || {})
+  return source
+}
+```
+
+The sync worker itself already runs in a separate process through `sync-rpc`, so the returned resolver can use async `execFile` internally while the public `configorama.sync()` call blocks until the worker returns.
+
+The plugin should include:
+
+```text
+plugins/onepassword/sync-factory.js
+```
+
+which exports the same factory as `index.js` or a thin wrapper around it.
+
+`syncOptions` must be JSON-serializable. Reject non-serializable options such as injected `execFile` when sync mode is used.
+
+## Error handling
+
+Errors should be explicit and actionable:
+
+- unknown alias: `Unknown 1Password alias "npm". Configure refs.npm.`
+- invalid alias: `Invalid 1Password alias "npm.prod". Aliases may contain only letters, numbers, and underscores.`
+- missing CLI: `1Password CLI "op" was not found on PATH. Install 1Password CLI or remove the op resolver.`
+- signin failure: `1Password CLI could not read the item. Run op signin, unlock 1Password app integration, or configure OP_SERVICE_ACCOUNT_TOKEN.`
+- unsupported public share link: `Public 1Password share links are not supported. Use Copy Private Link or an op:// secret reference.`
+- invalid private link: `Invalid 1Password private link. Expected query parameter "i" with the item ID.`
+- ambiguous field: `1Password item "x" has multiple candidate secret fields: notesPlain, password. Set field explicitly.`
+- ambiguous section field: `1Password item "x" has multiple fields labeled "token". Set section explicitly.`
+- missing field: `Field "password" was not found in 1Password item "x".`
+- no inferred field: `1Password item "x" has no obvious secret field. Set field explicitly.`
+- missing key path: `Key path "NPM_TOKEN" was not found in 1Password field "notesPlain".`
+- parse failure: `Could not parse 1Password field "notesPlain" as INI/dotenv.`
+
+Do not include secret values, full private links, public link tokens, stdout, or stderr in error messages.
+
+## Files to add
+
+```text
+plugins/onepassword/
+  README.md
+  index.js
+  index.test.js
+  op-cli.js
+  op-cli.test.js
+  parser.js
+  parser.test.js
+  sync-factory.js
+  package.json
+```
+
+Optional example:
+
+```text
+plugins/onepassword/example/
+  config.yml
+  usage.js
+```
+
+Core files likely to update:
+
+```text
+package.json
+src/index.js
+src/sync.js
+src/utils/introspection/audit.js
+README.md
+index.d.ts
+```
+
+## Tests
+
+### Parser tests
+
+- parses `KEY=value`
+- ignores `#` comments
+- ignores `;` comments if supported by the parser
+- strips no useful characters from values
+- supports section paths
+- errors on missing key
+- preserves empty string values when present
+- does not parse whole value unless key path is requested
+- does not trim raw values returned by `${op:alias}`
+
+### Syntax and normalization tests
+
+- parses `${op:npm}`
+- parses `${op:npm.NPM_TOKEN}`
+- rejects aliases containing dots, hyphens, spaces, or slashes
+- parses `${op(op://vault/item/notesPlain)}`
+- parses `${op(op://vault/item/notesPlain).NPM_TOKEN}`
+- parses `${op(item-id).NPM_TOKEN}`
+- parses `${op(My Database Login).password}`
+- parses private item link function syntax without being confused by dots, query params, or `&`
+- extracts `i` and `v` from private item links
+- drops `a`, `h`, and raw URL from `opReferences` metadata
+- rejects private item link colon syntax
+- rejects raw `op://` colon syntax with a pointer to `${op(op://...)}`
+- rejects public share links
+- accepts object ref with `{ item, vault, section, field }`
+- rejects object ref that combines `item` and `ref`
+
+### CLI utility tests
+
+Use dependency injection for `execFile`; do not call real `op` in unit tests.
+
+- `readSecretRef()` calls `op read --no-newline <ref>`
+- `getItem()` calls `op item get <spec> --format json --reveal`
+- vault/account/config options become CLI args
+- private link vault becomes `--vault`
+- `ENOENT` becomes missing-CLI error
+- signin-ish non-zero exit becomes sanitized auth error
+- not-found non-zero exit becomes sanitized not-found error
+- stdout JSON is parsed for item fetches
+- stderr is not included in thrown messages
+
+### Field selection tests
+
+- explicit field wins over inference
+- explicit field matches `id`
+- explicit field matches `label`
+- explicit field matches `purpose`
+- explicit section disambiguates duplicate labels
+- duplicate labels without section throw ambiguity
+- single `notesPlain` candidate is inferred
+- single `password` candidate is inferred
+- single concealed token-like candidate is inferred
+- `notesPlain` plus `password` throws ambiguity
+- username/email/url fields are ignored for inference
+- no candidates throws no-secret-field error
+
+### Resolver tests
+
+- alias string maps to secret ref read
+- alias string maps to item get when not a ref/link
+- alias object maps to item get with vault
+- private link maps to item get with item ID and vault ID
+- `${op:alias}` returns raw selected field
+- `${op:alias.KEY}` parses INI note and returns key
+- `${op:alias.section.KEY}` parses INI section and returns key
+- metadata records refs but not secret values
+- `skipResolution` returns placeholders and records metadata
+- cache prevents duplicate CLI calls for the same item/ref
+- failed calls are not cached
+- `clearCache()` clears caches and metadata
+
+### Sync tests
+
+- `configorama.sync()` can use `createOnePasswordResolver()` through `syncFactory`
+- sync mode rejects non-serializable injection options
+- sync mode returns the same resolved config as async mode for mocked `op`
+- sync mode collects `opReferences` metadata when `returnMetadata: true`
+
+### Core packaging tests
+
+- `require('configorama/plugins/cloudformation')` resolves from package exports
+- `require('configorama/plugins/onepassword')` resolves from package exports
+- `npm pack --dry-run` includes plugin `index.js` files and excludes plugin tests, examples, and nested lockfiles
+
+### Audit/safe-mode tests
+
+- `audit()` reports `op` as high-risk `remote_secret_read`
+- audit finding includes `sensitive: true`
+- safe mode blocks actual resolution by default
+- audit/inspect can still register the plugin with `blockCustomResolvers: false`
+
+### Optional real CLI smoke test
+
+Add a gated test that runs only when:
+
+```text
+CONFIGORAMA_OP_E2E=1
+CONFIGORAMA_OP_TEST_REF=op://...
+```
+
+The test should:
+
+- call `op read --no-newline` through the utility
+- assert a non-empty value
+- never print the value
+- skip by default
+
+Do not require this test in normal CI.
+
+## Documentation
+
+`plugins/onepassword/README.md` should cover:
+
+- installing 1Password CLI as a prerequisite
+- enabling/signing into CLI or using `OP_SERVICE_ACCOUNT_TOKEN`
+- resolver setup
+- alias syntax
+- direct item syntax
+- direct secret ref syntax
+- private item link syntax
+- unsupported public share links
+- field inference rules
+- explicit `field` and `section`
+- ambiguity errors
+- INI/dotenv notes with comments
+- raw return behavior for `${op:alias}`
+- security model: no persistence, no logging, values still enter resolved config
+- `skipResolution`
+- async and sync usage
+- safe-mode/audit behavior
+
+Root README should add a short 1Password entry in Bundled Plugins after CloudFormation and update CloudFormation wording if needed to reflect the package export fix.
+
+## Implementation order
+
+1. Fix root package exports/files for `plugins/cloudformation` and `plugins/onepassword`.
+2. Add sync plugin contract in `src/sync.js` (including worker `collectMetadata` collection) with tests using a tiny mock plugin.
+3. Add sensitive custom resolver audit support in `src/index.js` and `src/utils/introspection/audit.js`.
+4. Add `plugins/onepassword/package.json`.
+5. Build and test `parser.js` for INI/dotenv key path reads.
+6. Build and test private link parsing and reference normalization.
+7. Build and test `op-cli.js` with injected `execFile`.
+8. Build field selection and inference against representative `op item get --format json --reveal` fixtures.
+9. Build resolver syntax parsing, caching, metadata, and `skipResolution`.
+10. Add `sync-factory.js` and sync tests.
+11. Add README and example usage.
+12. Add root README bundled plugin section.
+13. Add optional gated real-CLI smoke test.
+14. Run full tests and type checks.
+
+## Acceptance criteria
+
+- Configorama can resolve `${op:npm.NPM_TOKEN}` from an INI-style secure note.
+- Configorama can resolve `${op:db}` from an item with a single unambiguous password field.
+- Configorama can resolve an `op://` secret reference with `op read --no-newline`.
+- Configorama can resolve a private item link copied from 1Password by extracting item ID and vault ID.
+- Public share links are rejected with a clear message.
+- Ambiguous items fail with a clear instruction to set `field` and optionally `section`.
+- Missing `op` binary and signin/auth problems produce sanitized actionable errors.
+- No default tests call real 1Password.
+- Secret values are absent from metadata and error messages.
+- Full private links are absent from `opReferences` metadata and placeholders.
+- The plugin works through both async and sync Configorama APIs.
+- The root package exports bundled plugin subpaths.
+- Audit reports the plugin as sensitive/high-risk remote secret access.
+- Safe mode blocks actual secret resolution by default.
+
+## Follow-ups outside this plan
+
+- `DEFAULT_VAR_SYNTAX` in `src/utils/parsing/parse.js:13` is an older copy of the variable char class without `&`, so the `configorama/parse-file` subpath will not match private-link variables. Align it with `buildVariableSyntax` in a separate change.

--- a/package.json
+++ b/package.json
@@ -6,16 +6,22 @@
   "types": "index.d.ts",
   "exports": {
     ".": "./src/index.js",
-    "./parse-file": "./src/utils/parsing/parse.js"
+    "./parse-file": "./src/utils/parsing/parse.js",
+    "./plugins/cloudformation": "./plugins/cloudformation/index.js",
+    "./plugins/onepassword": "./plugins/onepassword/index.js"
   },
   "files": [
     "cli.js",
     "src",
+    "plugins",
     "types",
     "index.d.ts",
     "package.json",
     "package-lock.json",
-    "README.md"
+    "README.md",
+    "!plugins/*/*.test.js",
+    "!plugins/*/example",
+    "!plugins/*/node_modules"
   ],
   "bin": {
     "config": "./cli.js",

--- a/plugins/onepassword/README.md
+++ b/plugins/onepassword/README.md
@@ -1,0 +1,5 @@
+# configorama 1Password plugin
+
+Resolves configuration values from 1Password through the `op` CLI.
+
+Documentation forthcoming.

--- a/plugins/onepassword/README.md
+++ b/plugins/onepassword/README.md
@@ -1,5 +1,157 @@
 # configorama 1Password plugin
 
-Resolves configuration values from 1Password through the `op` CLI.
+Resolves configuration values from 1Password through the [`op` CLI](https://developer.1password.com/docs/cli/).
 
-Documentation forthcoming.
+Secrets are fetched at resolution time. The plugin never persists them, never logs CLI output, and never passes resolved values as command-line arguments. Resolved values do enter the config object returned to your code — treat that object as sensitive.
+
+## Prerequisites
+
+- Install the [1Password CLI](https://developer.1password.com/docs/cli/get-started/) and make sure `op` is on `PATH`.
+- Sign in with `op signin`, enable the 1Password app integration, or set `OP_SERVICE_ACCOUNT_TOKEN`. The CLI reads `OP_ACCOUNT`, `OP_CONFIG_DIR`, and `OP_SERVICE_ACCOUNT_TOKEN` on its own — the plugin does not manage auth.
+
+## Setup
+
+```js
+const configorama = require('configorama')
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+const opResolver = createOnePasswordResolver({
+  refs: {
+    npm: 'op://production/npm-automation/notesPlain',
+    database: {
+      item: 'database-prod',
+      vault: 'production',
+      field: 'password'
+    },
+    github: {
+      item: 'GitHub',
+      vault: 'development',
+      section: 'credentials',
+      field: 'personal_token'
+    },
+    copiedLink: 'https://start.1password.com/open/i?a=ACCT&v=VAULT_ID&i=ITEM_ID&h=my.1password.com'
+  },
+  // account: 'my',            // passed to op as --account
+  // configDir: '/op/config',  // passed to op as --config
+  // skipResolution: true,     // collect metadata, return placeholders, never call op
+})
+
+const config = await configorama('config.yml', {
+  variableSources: [opResolver]
+})
+```
+
+Options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `refs` | object | Alias map. Values may be an `op://` secret reference, an item ID/name, a private item link, or `{ item, vault, section, field }` / `{ ref }` / `{ url }` |
+| `account` | string | Passed to `op` as `--account` |
+| `configDir` | string | Passed to `op` as `--config` |
+| `skipResolution` | boolean | Record metadata and return deterministic placeholders without calling `op` |
+
+## Alias syntax (recommended)
+
+```yaml
+npmToken: ${op:npm.NPM_TOKEN}
+dbPassword: ${op:database}
+rawNote: ${op:npm}
+nested: ${op:npm.database.password}
+```
+
+Alias names may contain only letters, numbers, and underscores. Dots separate the alias from a key path.
+
+## Direct function syntax
+
+```yaml
+directItem: ${op(item-id-example).NPM_TOKEN}
+spacedName: ${op(My Database Login).password}
+directRef: ${op(op://vault/item/field)}
+directRefKey: ${op(op://vault/item/notesPlain).NPM_TOKEN}
+privateLink: ${op(https://start.1password.com/open/i?a=ACCT&v=VAULT_ID&i=ITEM_ID&h=my.1password.com).NPM_TOKEN}
+```
+
+The parentheses give the parser a reliable boundary for specs containing dots, slashes, spaces, or query parameters. Prefer aliases for readability and auditability.
+
+### Unsupported syntax
+
+- `${op:op://vault/item/field}` — colon syntax is reserved for aliases. Error message points you to `${op(op://vault/item/field)}`.
+- Private links in colon syntax.
+- Public "share with anyone" links (`share.1password.com`) in any position. Use **Copy Private Link** or an `op://` secret reference instead.
+
+## Private item links
+
+Links copied with **Copy Private Link** are supported:
+
+```text
+https://start.1password.com/open/i?a=ACCOUNT&v=VAULT_ID&i=ITEM_ID&h=my.1password.com
+onepassword://open/i?a=ACCOUNT&v=VAULT_ID&i=ITEM_ID&h=my.1password.com
+```
+
+The plugin extracts `i` (item ID) and `v` (vault ID) and fetches with `op item get <itemId> --vault <vaultId>`. The `a`/`h` parameters and the raw URL are never stored in metadata. A link without `v` still resolves, with a warning diagnostic — service accounts and duplicate item names may require vault scoping.
+
+## Field selection
+
+With an explicit `field` on a ref, the plugin matches against the 1Password field `id`, `label`, and `purpose` (case-insensitive). `section` matches `section.id`/`section.label` and is required when the same label exists in multiple sections.
+
+Without a configured `field`, the plugin infers a single secret field:
+
+- `notesPlain`/notes, `purpose: PASSWORD`, `type: CONCEALED`, or secret-like labels (`password`, `token`, `api_key`, `secret`, `credential`, `private key`) are candidates
+- username, email, URL, and other metadata fields are ignored
+- exactly one candidate wins; zero or multiple candidates throw an error telling you to set `field` (and `section`)
+
+Ambiguity is always an error — the plugin never silently prefers `notesPlain` over `password`.
+
+In direct/alias syntax without a configured field, the first key path segment may select a field by name: `${op(My Login).password}` picks the `password` field. If no field matches, the segment is treated as an INI key inside the inferred field: `${op(note-item).NPM_TOKEN}`.
+
+## Structured notes (INI/dotenv)
+
+A secure note like:
+
+```ini
+# npm automation token
+NPM_TOKEN=npm_xxx
+
+[database]
+password=s3cr3t
+```
+
+resolves as:
+
+```yaml
+npmToken: ${op:npm.NPM_TOKEN}          # npm_xxx
+dbPassword: ${op:npm.database.password} # s3cr3t
+rawNote: ${op:npm}                      # the whole note text, unparsed
+```
+
+`${op:alias}` always returns the raw field text — even when it contains `=`. Parsing only happens when a key path is requested, so tokens, base64, and connection strings are never corrupted.
+
+## skipResolution
+
+With `skipResolution: true` the resolver records metadata and returns deterministic placeholders without calling `op`:
+
+```text
+[OP:alias:npm.NPM_TOKEN]
+[OP:secretRef:op://vault/item/field]
+[OP:item:item-id:NPM_TOKEN]
+[OP:privateLink:item-id]
+```
+
+## Sync usage
+
+```js
+const config = configorama.sync('config.yml', {
+  variableSources: [createOnePasswordResolver({ refs })]
+})
+```
+
+Sync mode rebuilds the resolver inside a worker process from JSON-serializable options and always uses the real `op` binary.
+
+## Safe mode and audit
+
+- `safeMode: true` blocks all custom resolvers during resolution, including this one.
+- `configorama.audit()` registers the plugin without fetching secrets and reports a high-severity `remote_secret_read` finding, because this resolver returns secret material.
+
+## Metadata
+
+With `returnMetadata: true`, references are collected under `metadata.opReferences` — reference kinds, item/vault IDs, fields, key paths, and config paths. Secret values, full private links, and CLI output are never recorded.

--- a/plugins/onepassword/README.md
+++ b/plugins/onepassword/README.md
@@ -152,6 +152,14 @@ Sync mode rebuilds the resolver inside a worker process from JSON-serializable o
 
 1Password app-integration auth is per `op` process. The resolver runs the first `op` call alone and queues the rest behind it, so a config referencing many items triggers at most one biometric/authorization prompt per resolution run instead of one per item.
 
+The 1Password dialog names the terminal app (OS-attributed, not customizable), so before the first call the resolver prints a context line to stderr in interactive terminals:
+
+```text
+configorama: requesting 3 items from 1Password (expect an authorization prompt)
+```
+
+The hint is TTY-only — silent in CI and pipes.
+
 ## Safe mode and audit
 
 - `safeMode: true` blocks all custom resolvers during resolution, including this one.

--- a/plugins/onepassword/README.md
+++ b/plugins/onepassword/README.md
@@ -148,6 +148,10 @@ const config = configorama.sync('config.yml', {
 
 Sync mode rebuilds the resolver inside a worker process from JSON-serializable options and always uses the real `op` binary.
 
+## Auth prompts
+
+1Password app-integration auth is per `op` process. The resolver runs the first `op` call alone and queues the rest behind it, so a config referencing many items triggers at most one biometric/authorization prompt per resolution run instead of one per item.
+
 ## Safe mode and audit
 
 - `safeMode: true` blocks all custom resolvers during resolution, including this one.

--- a/plugins/onepassword/README.md
+++ b/plugins/onepassword/README.md
@@ -160,6 +160,11 @@ configorama: requesting 3 items from 1Password (expect an authorization prompt)
 
 The hint is TTY-only — silent in CI and pipes.
 
+## Security model
+
+- Secrets are fetched from `op` at resolution time. The plugin never writes them to disk, never logs CLI output, and never passes resolved values as command-line arguments. Resolved values **do** enter the config object returned to your code — treat that object as sensitive (don't log it, commit it, or emit it to an untrusted sink).
+- **Direct syntax reads whatever your `op` session can reach.** `${op(op://any-vault/any-item/field)}`, direct item IDs, and private links are not restricted to the aliases in `refs`. If you resolve a config file you do not fully trust while a 1Password session is unlocked, that config can read any secret the session can access. For untrusted config, run with `safeMode: true` (which blocks all custom resolvers) or audit first — `configorama.audit()` flags this resolver as high-severity `remote_secret_read`.
+
 ## Safe mode and audit
 
 - `safeMode: true` blocks all custom resolvers during resolution, including this one.

--- a/plugins/onepassword/README.md
+++ b/plugins/onepassword/README.md
@@ -48,6 +48,7 @@ Options:
 | `refs` | object | Alias map. Values may be an `op://` secret reference, an item ID/name, a private item link, or `{ item, vault, section, field }` / `{ ref }` / `{ url }` |
 | `account` | string | Passed to `op` as `--account` |
 | `configDir` | string | Passed to `op` as `--config` |
+| `opPath` | string | Path to the `op` binary (defaults to `op` on `PATH`) |
 | `skipResolution` | boolean | Record metadata and return deterministic placeholders without calling `op` |
 
 ## Alias syntax (recommended)

--- a/plugins/onepassword/example/config.yml
+++ b/plugins/onepassword/example/config.yml
@@ -1,0 +1,3 @@
+npmToken: ${op:npm.NPM_TOKEN}
+dbPassword: ${op:database}
+rawNote: ${op:npm}

--- a/plugins/onepassword/example/usage.js
+++ b/plugins/onepassword/example/usage.js
@@ -1,0 +1,28 @@
+/* Example usage of the 1Password resolver plugin
+   Run with a signed-in op CLI: node usage.js */
+const path = require('path')
+const configorama = require('../../../src')
+const createOnePasswordResolver = require('../index')
+
+const opResolver = createOnePasswordResolver({
+  refs: {
+    npm: 'op://production/npm-automation/notesPlain',
+    database: {
+      item: 'database-prod',
+      vault: 'production',
+      field: 'password',
+    },
+  },
+})
+
+async function main() {
+  const config = await configorama(path.join(__dirname, 'config.yml'), {
+    variableSources: [opResolver],
+  })
+  console.log('resolved keys', Object.keys(config))
+}
+
+main().catch((err) => {
+  console.error('example failed', err.message)
+  process.exit(1)
+})

--- a/plugins/onepassword/fields.js
+++ b/plugins/onepassword/fields.js
@@ -47,19 +47,36 @@ function selectField(item, options = {}) {
  * @returns {object} Matched field
  */
 function selectExplicit(item, fields, wanted, section) {
+  const found = trySelectField(item, { field: wanted, section })
+  if (!found) {
+    throw new Error(`Field "${wanted}" was not found in 1Password item "${itemName(item)}".`)
+  }
+  return found
+}
+
+/**
+ * Match a field by name, returning null when nothing matches.
+ * Still throws on ambiguity - duplicate labels always need a section.
+ * @param {object} item - Parsed op item get JSON
+ * @param {object} options - { field, section }
+ * @returns {object|null} Matched field or null
+ */
+function trySelectField(item, options) {
+  const fields = item.fields || []
+  const wanted = options.field
   let candidates = fields.filter((field) => {
     return matches(field.id, wanted) || matches(field.label, wanted) || matches(field.purpose, wanted)
   })
 
-  if (section) {
+  if (options.section) {
     candidates = candidates.filter((field) => {
       const fieldSection = field.section || {}
-      return matches(fieldSection.id, section) || matches(fieldSection.label, section)
+      return matches(fieldSection.id, options.section) || matches(fieldSection.label, options.section)
     })
   }
 
   if (candidates.length === 0) {
-    throw new Error(`Field "${wanted}" was not found in 1Password item "${itemName(item)}".`)
+    return null
   }
   if (candidates.length > 1) {
     throw new Error(`1Password item "${itemName(item)}" has multiple fields labeled "${wanted}". Set section explicitly.`)
@@ -106,4 +123,4 @@ function inferField(item, fields) {
   throw new Error(`1Password item "${itemName(item)}" has no obvious secret field. Set field explicitly.`)
 }
 
-module.exports = { selectField }
+module.exports = { selectField, trySelectField }

--- a/plugins/onepassword/fields.js
+++ b/plugins/onepassword/fields.js
@@ -1,0 +1,109 @@
+/* Selects a field from op item get JSON, explicitly or by inference
+   Ambiguity is always an error - never silently prefers one secret field over another */
+
+const SECRET_LABELS = new Set(['password', 'token', 'api_key', 'api key', 'secret', 'credential', 'private key'])
+const IGNORED_PURPOSES = new Set(['USERNAME'])
+const IGNORED_TYPES = new Set(['URL'])
+const IGNORED_LABELS = new Set(['username', 'email', 'url', 'website', 'created', 'updated', 'title'])
+
+/**
+ * @param {object} item - Parsed op item get JSON
+ * @returns {string} Display name for error messages
+ */
+function itemName(item) {
+  return item.title || item.id || 'unknown'
+}
+
+/**
+ * @param {string|undefined} value - Field attribute
+ * @param {string} wanted - Configured name
+ * @returns {boolean} Case-insensitive equality
+ */
+function matches(value, wanted) {
+  return typeof value === 'string' && value.toLowerCase() === wanted.toLowerCase()
+}
+
+/**
+ * Select a field from an item.
+ * With options.field: explicit matching on id/label/purpose (+ section).
+ * Without: inference over secret-content candidates; ambiguity throws.
+ * @param {object} item - Parsed op item get JSON
+ * @param {object} [options] - { field, section }
+ * @returns {object} The selected field object
+ */
+function selectField(item, options = {}) {
+  const fields = item.fields || []
+  if (options.field) {
+    return selectExplicit(item, fields, options.field, options.section)
+  }
+  return inferField(item, fields)
+}
+
+/**
+ * @param {object} item - Item for error messages
+ * @param {object[]} fields - item.fields
+ * @param {string} wanted - Configured field name
+ * @param {string} [section] - Configured section name
+ * @returns {object} Matched field
+ */
+function selectExplicit(item, fields, wanted, section) {
+  let candidates = fields.filter((field) => {
+    return matches(field.id, wanted) || matches(field.label, wanted) || matches(field.purpose, wanted)
+  })
+
+  if (section) {
+    candidates = candidates.filter((field) => {
+      const fieldSection = field.section || {}
+      return matches(fieldSection.id, section) || matches(fieldSection.label, section)
+    })
+  }
+
+  if (candidates.length === 0) {
+    throw new Error(`Field "${wanted}" was not found in 1Password item "${itemName(item)}".`)
+  }
+  if (candidates.length > 1) {
+    throw new Error(`1Password item "${itemName(item)}" has multiple fields labeled "${wanted}". Set section explicitly.`)
+  }
+  return candidates[0]
+}
+
+/**
+ * @param {object} field - Item field
+ * @returns {boolean} True when the field likely holds secret content
+ */
+function isSecretCandidate(field) {
+  if (field.value === undefined || field.value === '') return false
+  const label = (field.label || '').toLowerCase()
+  const purpose = (field.purpose || '').toUpperCase()
+  const type = (field.type || '').toUpperCase()
+
+  if (IGNORED_PURPOSES.has(purpose) || IGNORED_TYPES.has(type) || IGNORED_LABELS.has(label)) {
+    return false
+  }
+  if (matches(field.id, 'notesPlain') || matches(field.label, 'notesPlain') || purpose === 'NOTES') return true
+  if (purpose === 'PASSWORD') return true
+  if (type === 'CONCEALED') return true
+  if (SECRET_LABELS.has(label)) return true
+  return false
+}
+
+/**
+ * Infer the single secret-content field or throw.
+ * Never prefers notesPlain over password (or vice versa) - two candidates is an error.
+ * @param {object} item - Item for error messages
+ * @param {object[]} fields - item.fields
+ * @returns {object} Inferred field
+ */
+function inferField(item, fields) {
+  const candidates = fields.filter(isSecretCandidate)
+  if (candidates.length === 1) {
+    return candidates[0]
+  }
+  if (candidates.length > 1) {
+    const labels = candidates.map((field) => field.label || field.id).join(', ')
+    throw new Error(`1Password item "${itemName(item)}" has multiple candidate secret fields: ${labels}. Set field explicitly.`)
+  }
+  throw new Error(`1Password item "${itemName(item)}" has no obvious secret field. Set field explicitly.`)
+}
+
+module.exports = { selectField }

--- a/plugins/onepassword/fields.test.js
+++ b/plugins/onepassword/fields.test.js
@@ -1,0 +1,138 @@
+/* Tests for 1Password field selection and inference
+   Fixtures mirror op item get --format json --reveal output shapes */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const { selectField } = require('./fields')
+
+const loginItem = {
+  id: 'login-1',
+  title: 'My Database Login',
+  fields: [
+    { id: 'username', type: 'STRING', purpose: 'USERNAME', label: 'username', value: 'admin@example.com' },
+    { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'pw-secret' },
+    { id: 'notesPlain', type: 'STRING', purpose: 'NOTES', label: 'notesPlain' },
+    { id: 'website', type: 'URL', label: 'website', value: 'https://db.example.com' },
+  ],
+}
+
+const secureNoteItem = {
+  id: 'note-1',
+  title: 'npm automation',
+  fields: [
+    { id: 'notesPlain', type: 'STRING', purpose: 'NOTES', label: 'notesPlain', value: 'NPM_TOKEN=npm_xxx' },
+  ],
+}
+
+const ambiguousItem = {
+  id: 'ambig-1',
+  title: 'Mixed Item',
+  fields: [
+    { id: 'notesPlain', type: 'STRING', purpose: 'NOTES', label: 'notesPlain', value: 'NOTE=1' },
+    { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'hunter2' },
+  ],
+}
+
+const apiCredentialItem = {
+  id: 'api-1',
+  title: 'Service API',
+  fields: [
+    { id: 'u1', type: 'STRING', label: 'username', value: 'svc-user' },
+    { id: 'c1', type: 'CONCEALED', label: 'credential', value: 'api-secret' },
+  ],
+}
+
+const duplicateLabelItem = {
+  id: 'dup-1',
+  title: 'Two Tokens',
+  fields: [
+    { id: 't1', type: 'CONCEALED', label: 'token', value: 'token-one', section: { id: 's1', label: 'staging' } },
+    { id: 't2', type: 'CONCEALED', label: 'token', value: 'token-two', section: { id: 's2', label: 'production' } },
+  ],
+}
+
+const noSecretItem = {
+  id: 'plain-1',
+  title: 'Plain Info',
+  fields: [
+    { id: 'username', type: 'STRING', purpose: 'USERNAME', label: 'username', value: 'someone' },
+    { id: 'website', type: 'URL', label: 'website', value: 'https://example.com' },
+  ],
+}
+
+/* Explicit selection */
+
+test('explicit field matches id', () => {
+  assert.is(selectField(loginItem, { field: 'password' }).value, 'pw-secret')
+})
+
+test('explicit field matches label case-insensitively', () => {
+  assert.is(selectField(apiCredentialItem, { field: 'CREDENTIAL' }).value, 'api-secret')
+})
+
+test('explicit field matches purpose', () => {
+  assert.is(selectField(loginItem, { field: 'PASSWORD' }).value, 'pw-secret')
+})
+
+test('explicit field wins over inference', () => {
+  assert.is(selectField(ambiguousItem, { field: 'notesPlain' }).value, 'NOTE=1')
+})
+
+test('explicit section disambiguates duplicate labels', () => {
+  assert.is(selectField(duplicateLabelItem, { field: 'token', section: 'production' }).value, 'token-two')
+})
+
+test('duplicate labels without section throw section ambiguity', () => {
+  try {
+    selectField(duplicateLabelItem, { field: 'token' })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /multiple fields labeled "token". Set section explicitly/)
+  }
+})
+
+test('missing explicit field throws not-found', () => {
+  try {
+    selectField(loginItem, { field: 'nope' })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Field "nope" was not found in 1Password item "My Database Login"/)
+  }
+})
+
+/* Inference */
+
+test('single password candidate is inferred (empty notesPlain ignored)', () => {
+  assert.is(selectField(loginItem, {}).value, 'pw-secret')
+})
+
+test('single notesPlain candidate is inferred', () => {
+  assert.is(selectField(secureNoteItem, {}).value, 'NPM_TOKEN=npm_xxx')
+})
+
+test('single concealed credential-like candidate is inferred', () => {
+  assert.is(selectField(apiCredentialItem, {}).value, 'api-secret')
+})
+
+test('notesPlain plus password throws ambiguity naming candidates', () => {
+  try {
+    selectField(ambiguousItem, {})
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /multiple candidate secret fields/)
+    assert.match(err.message, /notesPlain/)
+    assert.match(err.message, /password/)
+    assert.match(err.message, /Set field explicitly/)
+    assert.is(err.message.includes('hunter2'), false)
+  }
+})
+
+test('username, email, and url fields are ignored for inference', () => {
+  try {
+    selectField(noSecretItem, {})
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /has no obvious secret field. Set field explicitly/)
+  }
+})
+
+test.run()

--- a/plugins/onepassword/index.js
+++ b/plugins/onepassword/index.js
@@ -25,6 +25,7 @@ const opVariableSyntax = /^op(?::|\()/
  * @param {object} [options.refs] - Alias map: name -> string ref, item name, private link, or { item, vault, section, field } / { ref } / { url }
  * @param {string} [options.account] - Passed to op as --account
  * @param {string} [options.configDir] - Passed to op as --config
+ * @param {string} [options.opPath] - Path to the op binary (defaults to "op" on PATH)
  * @param {boolean} [options.skipResolution] - Collect metadata and return placeholders without calling op
  * @param {Function} [options.execFile] - execFile injection for tests (not serializable; unavailable in sync mode)
  * @returns {object} Variable source configuration with resolver and metadata collector
@@ -34,6 +35,7 @@ function createOnePasswordResolver(options = {}) {
     refs = {},
     account,
     configDir,
+    opPath,
     skipResolution = false,
     execFile,
   } = options
@@ -51,7 +53,7 @@ function createOnePasswordResolver(options = {}) {
   const secretRefCache = new Map()
   const itemCache = new Map()
 
-  const cliOptions = { account, configDir, execFile }
+  const cliOptions = { account, configDir, opPath, execFile }
   const scopeKey = `${account || ''}|${configDir || ''}`
 
   /**
@@ -246,7 +248,7 @@ function createOnePasswordResolver(options = {}) {
    * @returns {object} JSON-serializable options for the sync worker
    */
   function buildSyncOptions() {
-    const syncOptions = { refs, account, configDir, skipResolution }
+    const syncOptions = { refs, account, configDir, opPath, skipResolution }
     if (execFile) {
       // Functions cannot cross the JSON boundary into the sync worker;
       // flag it so sync-factory can fail loudly instead of silently

--- a/plugins/onepassword/index.js
+++ b/plugins/onepassword/index.js
@@ -6,6 +6,17 @@ const { selectField, trySelectField } = require('./fields')
 const { parseStructuredSecret, getKeyPath } = require('./parser')
 
 const OP_PREFIX = 'op'
+
+/**
+ * Tell interactive users why an authorization prompt is about to appear.
+ * The 1Password dialog only names the terminal app (OS-attributed), so this
+ * line supplies the configorama context. TTY-only: silent in CI and pipes.
+ * @param {number} count - Distinct op calls at cold start
+ */
+function logAuthHint(count) {
+  if (!process.stderr.isTTY) return
+  process.stderr.write(`configorama: requesting ${count} item${count === 1 ? '' : 's'} from 1Password (expect an authorization prompt)\n`)
+}
 // Supports: op:alias, op:alias.KEY, op(item), op(item).KEY
 const opVariableSyntax = /^op(?::|\()/
 
@@ -80,12 +91,21 @@ function createOnePasswordResolver(options = {}) {
   // op call runs alone; everything else queues behind its settlement and
   // then fans out in parallel against the authorized session.
   let coldStartCall = null
+  let coldStartCount = 0
+  let hintScheduled = false
 
   /**
    * @param {Function} fn - Producer returning a promise
    * @returns {Promise<*>} Producer result, gated behind the first call
    */
   function withColdStartLatch(fn) {
+    coldStartCount++
+    if (!hintScheduled) {
+      hintScheduled = true
+      // setImmediate lets the whole parallel fan-out register first so the
+      // hint reports an accurate item count.
+      setImmediate(() => logAuthHint(coldStartCount))
+    }
     if (!coldStartCall) {
       coldStartCall = fn()
       return coldStartCall
@@ -263,6 +283,8 @@ function createOnePasswordResolver(options = {}) {
       itemCache.clear()
       opReferences.length = 0
       coldStartCall = null
+      coldStartCount = 0
+      hintScheduled = false
     },
     syncFactory: require.resolve('./sync-factory'),
     syncOptions: buildSyncOptions(),

--- a/plugins/onepassword/index.js
+++ b/plugins/onepassword/index.js
@@ -239,7 +239,21 @@ function createOnePasswordResolver(options = {}) {
       opReferences.length = 0
     },
     syncFactory: require.resolve('./sync-factory'),
-    syncOptions: { refs, account, configDir, skipResolution },
+    syncOptions: buildSyncOptions(),
+  }
+
+  /**
+   * @returns {object} JSON-serializable options for the sync worker
+   */
+  function buildSyncOptions() {
+    const syncOptions = { refs, account, configDir, skipResolution }
+    if (execFile) {
+      // Functions cannot cross the JSON boundary into the sync worker;
+      // flag it so sync-factory can fail loudly instead of silently
+      // running the real op binary.
+      syncOptions.hasInjectedExecFile = true
+    }
+    return syncOptions
   }
 }
 

--- a/plugins/onepassword/index.js
+++ b/plugins/onepassword/index.js
@@ -66,12 +66,31 @@ function createOnePasswordResolver(options = {}) {
     if (cache.has(key)) {
       return cache.get(key)
     }
-    const promise = fn().catch((err) => {
+    const promise = withColdStartLatch(fn).catch((err) => {
       cache.delete(key)
       throw err
     })
     cache.set(key, promise)
     return promise
+  }
+
+  // 1Password app-integration auth prompts once per op PROCESS until a
+  // session exists. Parallel resolution of N distinct items would spawn N
+  // processes at cold start and trigger N biometric prompts, so the first
+  // op call runs alone; everything else queues behind its settlement and
+  // then fans out in parallel against the authorized session.
+  let coldStartCall = null
+
+  /**
+   * @param {Function} fn - Producer returning a promise
+   * @returns {Promise<*>} Producer result, gated behind the first call
+   */
+  function withColdStartLatch(fn) {
+    if (!coldStartCall) {
+      coldStartCall = fn()
+      return coldStartCall
+    }
+    return coldStartCall.catch(() => {}).then(fn)
   }
 
   /**
@@ -243,6 +262,7 @@ function createOnePasswordResolver(options = {}) {
       secretRefCache.clear()
       itemCache.clear()
       opReferences.length = 0
+      coldStartCall = null
     },
     syncFactory: require.resolve('./sync-factory'),
     syncOptions: buildSyncOptions(),

--- a/plugins/onepassword/index.js
+++ b/plugins/onepassword/index.js
@@ -1,0 +1,8 @@
+/* 1Password variable source for configorama
+   Resolves ${op:alias} and ${op(item)} references through the op CLI */
+
+function createOnePasswordResolver(options = {}) {
+  throw new Error('Not implemented')
+}
+
+module.exports = createOnePasswordResolver

--- a/plugins/onepassword/index.js
+++ b/plugins/onepassword/index.js
@@ -1,8 +1,247 @@
 /* 1Password variable source for configorama
    Resolves ${op:alias} and ${op(item)} references through the op CLI */
+const { readSecretRef, getItem } = require('./op-cli')
+const { validateAliasName, normalizeRefValue } = require('./normalize')
+const { selectField, trySelectField } = require('./fields')
+const { parseStructuredSecret, getKeyPath } = require('./parser')
 
+const OP_PREFIX = 'op'
+// Supports: op:alias, op:alias.KEY, op(item), op(item).KEY
+const opVariableSyntax = /^op(?::|\()/
+
+/**
+ * Creates a 1Password variable source resolver.
+ *
+ * Syntax:
+ *   ${op:alias}            — alias from refs, raw selected field
+ *   ${op:alias.KEY}        — alias, INI/dotenv key path into the field
+ *   ${op(spec)}            — direct item ID/name, op:// ref, or private link
+ *   ${op(spec).KEY}        — direct spec with key path
+ *
+ * Colon syntax is reserved for aliases; raw op:// refs and links must use
+ * function syntax so the parser has a reliable spec boundary.
+ *
+ * @param {object} options - Configuration options
+ * @param {object} [options.refs] - Alias map: name -> string ref, item name, private link, or { item, vault, section, field } / { ref } / { url }
+ * @param {string} [options.account] - Passed to op as --account
+ * @param {string} [options.configDir] - Passed to op as --config
+ * @param {boolean} [options.skipResolution] - Collect metadata and return placeholders without calling op
+ * @param {Function} [options.execFile] - execFile injection for tests (not serializable; unavailable in sync mode)
+ * @returns {object} Variable source configuration with resolver and metadata collector
+ */
 function createOnePasswordResolver(options = {}) {
-  throw new Error('Not implemented')
+  const {
+    refs = {},
+    account,
+    configDir,
+    skipResolution = false,
+    execFile,
+  } = options
+
+  const aliasRefs = {}
+  for (const alias of Object.keys(refs)) {
+    validateAliasName(alias)
+    aliasRefs[alias] = normalizeRefValue(refs[alias])
+  }
+
+  const opReferences = []
+  // Caches hold in-flight promises so concurrent references to the same
+  // item/ref share one op call. Failed promises are evicted immediately,
+  // so auth/not-found/parse failures are never cached.
+  const secretRefCache = new Map()
+  const itemCache = new Map()
+
+  const cliOptions = { account, configDir, execFile }
+  const scopeKey = `${account || ''}|${configDir || ''}`
+
+  /**
+   * @param {Map} cache - Promise cache
+   * @param {string} key - Cache key
+   * @param {Function} fn - Producer returning a promise
+   * @returns {Promise<*>} Shared promise
+   */
+  function cached(cache, key, fn) {
+    if (cache.has(key)) {
+      return cache.get(key)
+    }
+    const promise = fn().catch((err) => {
+      cache.delete(key)
+      throw err
+    })
+    cache.set(key, promise)
+    return promise
+  }
+
+  /**
+   * Parse an op variable string into its reference and key path.
+   * @param {string} varString - e.g. "op:npm.NPM_TOKEN" or "op(item-id).KEY"
+   * @returns {{reference: object, keyPath: string|undefined, alias: string|undefined}} Parsed parts
+   */
+  function parseVariable(varString) {
+    const trimmed = varString.trim()
+
+    const funcMatch = trimmed.match(/^op\((.*)\)(?:\.(.+))?$/)
+    if (funcMatch) {
+      const spec = funcMatch[1].trim()
+      if (!spec) {
+        throw new Error(`Invalid 1Password reference "${varString}". Expected \${op(item)}, \${op(op://vault/item/field)}, or a private link.`)
+      }
+      return { reference: normalizeRefValue(spec), keyPath: funcMatch[2], alias: undefined }
+    }
+
+    if (!trimmed.startsWith('op:')) {
+      throw new Error(`Invalid 1Password variable "${varString}".`)
+    }
+    const rest = trimmed.slice(3)
+    if (rest.startsWith('op://')) {
+      throw new Error(`Use \${op(${rest})} for direct secret references.`)
+    }
+
+    const dotIndex = rest.indexOf('.')
+    const alias = dotIndex === -1 ? rest : rest.slice(0, dotIndex)
+    const keyPath = dotIndex === -1 ? undefined : rest.slice(dotIndex + 1)
+
+    validateAliasName(alias)
+    const reference = aliasRefs[alias]
+    if (!reference) {
+      throw new Error(`Unknown 1Password alias "${alias}". Configure refs.${alias}.`)
+    }
+    return { reference, keyPath, alias }
+  }
+
+  /**
+   * @param {object} params - { reference, keyPath, alias }
+   * @returns {string} Deterministic placeholder (never links or secrets)
+   */
+  function placeholderFor({ reference, keyPath, alias }) {
+    if (alias) {
+      return `[OP:alias:${alias}${keyPath ? `.${keyPath}` : ''}]`
+    }
+    if (reference.kind === 'secretRef') {
+      return `[OP:secretRef:${reference.ref}]`
+    }
+    if (reference.kind === 'privateLink') {
+      return `[OP:privateLink:${reference.item}]`
+    }
+    return `[OP:item:${reference.item}${keyPath ? `:${keyPath}` : ''}]`
+  }
+
+  /**
+   * Fetch and select the backing field value for a normalized reference.
+   * For items without a configured field, the first key path segment may
+   * select a field directly: ${op(My Login).password} picks the password
+   * field, while ${op(note-item).NPM_TOKEN} falls back to inference and
+   * treats NPM_TOKEN as an INI key inside the inferred field.
+   * @param {object} reference - Normalized reference
+   * @param {string|undefined} keyPath - Requested key path
+   * @returns {Promise<{value: string, fieldName: string, remainingKeyPath: string|undefined}>} Selected value
+   */
+  async function fetchValue(reference, keyPath) {
+    if (reference.kind === 'secretRef') {
+      const value = await cached(secretRefCache, `${scopeKey}|${reference.ref}`, () => {
+        return readSecretRef(reference.ref, cliOptions)
+      })
+      return { value, fieldName: reference.ref, remainingKeyPath: keyPath }
+    }
+
+    const vault = reference.vault
+    const itemKey = `${scopeKey}|${vault || ''}|${reference.item}`
+    const item = await cached(itemCache, itemKey, () => {
+      return getItem(reference.item, { ...cliOptions, vault })
+    })
+
+    // Field selection is a pure function over the cached item JSON, so it
+    // needs no cache of its own - no op call is ever saved by one.
+    if (reference.field) {
+      const field = selectField(item, { field: reference.field, section: reference.section })
+      return { value: field.value, fieldName: field.label || field.id, remainingKeyPath: keyPath }
+    }
+
+    if (keyPath !== undefined) {
+      const dotIndex = keyPath.indexOf('.')
+      const firstSegment = dotIndex === -1 ? keyPath : keyPath.slice(0, dotIndex)
+      const fieldMatch = trySelectField(item, { field: firstSegment })
+      if (fieldMatch) {
+        const remaining = dotIndex === -1 ? undefined : keyPath.slice(dotIndex + 1)
+        return { value: fieldMatch.value, fieldName: fieldMatch.label || fieldMatch.id, remainingKeyPath: remaining }
+      }
+    }
+
+    const field = selectField(item, {})
+    return { value: field.value, fieldName: field.label || field.id, remainingKeyPath: keyPath }
+  }
+
+  /**
+   * @param {string} varString - Variable body without ${}
+   * @param {object} opts - Resolver options from core (unused)
+   * @param {object} currentObject - Config object being populated (unused)
+   * @param {object} valueObject - Core value context ({ originalSource, path })
+   * @returns {Promise<string>} Resolved value or placeholder
+   */
+  async function resolver(varString, opts, currentObject, valueObject) {
+    const parsed = parseVariable(varString)
+    const { reference, keyPath, alias } = parsed
+    const configPath = valueObject && valueObject.path ? valueObject.path.join('.') : undefined
+
+    const entry = {
+      raw: valueObject ? valueObject.originalSource : `\${${varString}}`,
+      resolved: `\${${varString}}`,
+      alias,
+      referenceKind: reference.kind,
+      ref: reference.kind === 'secretRef' ? reference.ref : undefined,
+      item: reference.item,
+      vault: reference.vault,
+      field: reference.field,
+      section: reference.section,
+      keyPath,
+      configPath,
+      sensitive: true,
+      risk: 'remote_secret_read',
+      source: 'remote',
+      skipped: skipResolution === true,
+    }
+    if (reference.warnings && reference.warnings.length) {
+      entry.diagnostics = reference.warnings.map((warning) => ({ ...warning, configPath }))
+    }
+    opReferences.push(entry)
+
+    if (skipResolution) {
+      return placeholderFor(parsed)
+    }
+
+    const { value, fieldName, remainingKeyPath } = await fetchValue(reference, keyPath)
+    if (entry.field === undefined && reference.kind !== 'secretRef') {
+      entry.field = fieldName
+    }
+
+    if (remainingKeyPath === undefined) {
+      return value
+    }
+    const parsedValue = parseStructuredSecret(value, { fieldName })
+    return getKeyPath(parsedValue, remainingKeyPath, fieldName)
+  }
+
+  return {
+    type: OP_PREFIX,
+    source: 'remote',
+    prefix: OP_PREFIX,
+    syntax: '${op:alias.KEY}, ${op(item).KEY}, or ${op(op://vault/item/field)}',
+    description: 'Resolves values from 1Password through the op CLI',
+    sensitive: true,
+    risk: 'remote_secret_read',
+    match: opVariableSyntax,
+    resolver,
+    metadataKey: 'opReferences',
+    collectMetadata: () => opReferences,
+    clearCache: () => {
+      secretRefCache.clear()
+      itemCache.clear()
+      opReferences.length = 0
+    },
+    syncFactory: require.resolve('./sync-factory'),
+    syncOptions: { refs, account, configDir, skipResolution },
+  }
 }
 
 module.exports = createOnePasswordResolver
+module.exports.opVariableSyntax = opVariableSyntax

--- a/plugins/onepassword/index.js
+++ b/plugins/onepassword/index.js
@@ -185,9 +185,13 @@ function createOnePasswordResolver(options = {}) {
     const { reference, keyPath, alias } = parsed
     const configPath = valueObject && valueObject.path ? valueObject.path.join('.') : undefined
 
+    // Direct private links put the full URL (with account/host params) in
+    // the variable string itself - redact it from opReferences entries.
+    const isDirectLink = reference.kind === 'privateLink' && !alias
+    const redacted = `\${op(...)${keyPath ? `.${keyPath}` : ''}}`
     const entry = {
-      raw: valueObject ? valueObject.originalSource : `\${${varString}}`,
-      resolved: `\${${varString}}`,
+      raw: isDirectLink ? redacted : (valueObject ? valueObject.originalSource : `\${${varString}}`),
+      resolved: isDirectLink ? redacted : `\${${varString}}`,
       alias,
       referenceKind: reference.kind,
       ref: reference.kind === 'secretRef' ? reference.ref : undefined,

--- a/plugins/onepassword/index.test.js
+++ b/plugins/onepassword/index.test.js
@@ -240,6 +240,19 @@ test('metadata records references but never secret values or URLs', async () => 
   assert.is(linkEntry.risk, 'remote_secret_read')
 })
 
+test('direct private link syntax is redacted in metadata', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ execFile: fake.execFile })
+  const linkVar = 'op(https://start.1password.com/open/i?a=ACCT&v=vault-id-123&i=item-id-456&h=my.1password.com).NPM_TOKEN'
+  await source.resolver(linkVar, {}, {}, vo(linkVar))
+  const [entry] = source.collectMetadata()
+  assert.is(entry.raw, '${op(...).NPM_TOKEN}')
+  assert.is(entry.resolved, '${op(...).NPM_TOKEN}')
+  const serialized = JSON.stringify(source.collectMetadata())
+  assert.is(serialized.includes('start.1password.com'), false)
+  assert.is(serialized.includes('ACCT'), false)
+})
+
 /* skipResolution */
 
 test('skipResolution returns placeholders and records skipped metadata', async () => {

--- a/plugins/onepassword/index.test.js
+++ b/plugins/onepassword/index.test.js
@@ -361,6 +361,52 @@ test('queued calls still run when the cold-start call fails', async () => {
   assert.is(results[1].value, 'db-secret')
 })
 
+test('auth hint on stderr names the number of items at cold start', async () => {
+  // drain hint timers scheduled by instances from earlier tests
+  await new Promise((resolve) => setImmediate(resolve))
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ refs: { a: 'note-item', b: 'database-prod' }, execFile: fake.execFile })
+
+  const written = []
+  const originalWrite = process.stderr.write
+  const originalIsTTY = process.stderr.isTTY
+  process.stderr.isTTY = true
+  process.stderr.write = (chunk) => { written.push(String(chunk)); return true }
+  try {
+    await Promise.all([
+      source.resolver('op:a', {}, {}, vo('op:a')),
+      source.resolver('op:b', {}, {}, vo('op:b')),
+    ])
+    // the hint is scheduled with setImmediate; let it flush before restoring
+    await new Promise((resolve) => setImmediate(resolve))
+  } finally {
+    process.stderr.write = originalWrite
+    process.stderr.isTTY = originalIsTTY
+  }
+  const hints = written.filter((line) => line.includes('1Password'))
+  assert.is(hints.length, 1, 'exactly one hint per resolution run')
+  assert.match(hints[0], /configorama: requesting 2 items from 1Password \(expect an authorization prompt\)/)
+})
+
+test('auth hint is silent when stderr is not a TTY', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ refs: { a: 'note-item' }, execFile: fake.execFile })
+
+  const written = []
+  const originalWrite = process.stderr.write
+  const originalIsTTY = process.stderr.isTTY
+  process.stderr.isTTY = false
+  process.stderr.write = (chunk) => { written.push(String(chunk)); return true }
+  try {
+    await source.resolver('op:a', {}, {}, vo('op:a'))
+    await new Promise((resolve) => setImmediate(resolve))
+  } finally {
+    process.stderr.write = originalWrite
+    process.stderr.isTTY = originalIsTTY
+  }
+  assert.is(written.filter((line) => line.includes('1Password')).length, 0)
+})
+
 /* Source contract */
 
 test('returned source carries sensitive metadata and sync contract', () => {

--- a/plugins/onepassword/index.test.js
+++ b/plugins/onepassword/index.test.js
@@ -1,0 +1,320 @@
+/* Tests for the 1Password variable source resolver
+   Mocked execFile throughout; never calls the real op CLI */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const configorama = require('../../src')
+const createOnePasswordResolver = require('./index')
+
+const INI_NOTE = `# npm automation token
+NPM_TOKEN=npm_xxx
+
+[database]
+password=s3cr3t
+`
+
+const items = {
+  'note-item': {
+    id: 'note-item',
+    title: 'npm automation',
+    fields: [{ id: 'notesPlain', type: 'STRING', purpose: 'NOTES', label: 'notesPlain', value: INI_NOTE }],
+  },
+  'database-prod': {
+    id: 'database-prod',
+    title: 'database-prod',
+    fields: [
+      { id: 'username', type: 'STRING', purpose: 'USERNAME', label: 'username', value: 'admin' },
+      { id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'db-secret' },
+    ],
+  },
+  'item-id-456': {
+    id: 'item-id-456',
+    title: 'Linked Item',
+    fields: [{ id: 'notesPlain', type: 'STRING', purpose: 'NOTES', label: 'notesPlain', value: INI_NOTE }],
+  },
+  'My Database Login': {
+    id: 'login-1',
+    title: 'My Database Login',
+    fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'login-secret' }],
+  },
+}
+
+/**
+ * Fake execFile returning fixtures for op read / op item get
+ * @param {object} [overrides] - { failFirst } to fail the first call
+ * @returns {{execFile: Function, calls: Array}} Fake and call log
+ */
+function fakeOp(overrides = {}) {
+  const calls = []
+  let failed = false
+  function execFile(cmd, args, opts, cb) {
+    calls.push({ cmd, args })
+    if (overrides.failFirst && !failed) {
+      failed = true
+      const err = Object.assign(new Error('fail'), { code: 1 })
+      return cb(err, '', 'item not found')
+    }
+    if (args[0] === 'read') {
+      return cb(null, INI_NOTE, '')
+    }
+    const spec = args[2]
+    const item = items[spec]
+    if (!item) {
+      const err = Object.assign(new Error('fail'), { code: 1 })
+      return cb(err, '', `"${spec}" isn't an item`)
+    }
+    cb(null, JSON.stringify(item), '')
+  }
+  return { execFile, calls }
+}
+
+/**
+ * Fake valueObject matching what the core resolver loop passes
+ * @param {string} varString - Variable body
+ * @returns {object} valueObject stub
+ */
+function vo(varString) {
+  return { originalSource: `\${${varString}}`, path: ['provider', 'key'] }
+}
+
+/* Resolution through configorama */
+
+test('alias secret ref resolves through op read', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ refs: { npm: 'op://prod/npm/notesPlain' }, execFile: fake.execFile })
+  const config = await configorama({ token: '${op:npm.NPM_TOKEN}' }, { variableSources: [source] })
+  assert.is(config.token, 'npm_xxx')
+  assert.equal(fake.calls[0].args.slice(0, 3), ['read', '--no-newline', 'op://prod/npm/notesPlain'])
+})
+
+test('alias item name resolves through op item get with inference', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ refs: { db: 'database-prod' }, execFile: fake.execFile })
+  const config = await configorama({ password: '${op:db}' }, { variableSources: [source] })
+  assert.is(config.password, 'db-secret')
+  assert.is(fake.calls[0].args[0], 'item')
+})
+
+test('alias object passes vault and field', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({
+    refs: { db: { item: 'database-prod', vault: 'production', field: 'password' } },
+    execFile: fake.execFile,
+  })
+  const config = await configorama({ password: '${op:db}' }, { variableSources: [source] })
+  assert.is(config.password, 'db-secret')
+  assert.is(fake.calls[0].args.includes('--vault'), true)
+  assert.is(fake.calls[0].args.includes('production'), true)
+})
+
+test('alias private link resolves via item and vault IDs', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({
+    refs: { linked: 'https://start.1password.com/open/i?a=ACCT&v=vault-id-123&i=item-id-456&h=my.1password.com' },
+    execFile: fake.execFile,
+  })
+  const config = await configorama({ token: '${op:linked.NPM_TOKEN}' }, { variableSources: [source] })
+  assert.is(config.token, 'npm_xxx')
+  assert.is(fake.calls[0].args[2], 'item-id-456')
+  assert.is(fake.calls[0].args.includes('--vault'), true)
+  assert.is(fake.calls[0].args.includes('vault-id-123'), true)
+})
+
+test('raw alias returns whole field text and section key paths work', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ refs: { npm: 'note-item' }, execFile: fake.execFile })
+  const config = await configorama(
+    {
+      rawNote: '${op:npm}',
+      token: '${op:npm.NPM_TOKEN}',
+      dbPassword: '${op:npm.database.password}',
+    },
+    { variableSources: [source] }
+  )
+  assert.is(config.rawNote, INI_NOTE)
+  assert.is(config.token, 'npm_xxx')
+  assert.is(config.dbPassword, 's3cr3t')
+})
+
+test('direct function syntax with op:// ref and key path', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ execFile: fake.execFile })
+  const config = await configorama(
+    {
+      whole: '${op(op://vault/item/notesPlain)}',
+      key: '${op(op://vault/item/notesPlain).NPM_TOKEN}',
+    },
+    { variableSources: [source] }
+  )
+  assert.is(config.whole, INI_NOTE)
+  assert.is(config.key, 'npm_xxx')
+})
+
+test('direct function syntax with item id and item name with spaces', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ execFile: fake.execFile })
+  const config = await configorama(
+    {
+      linked: '${op(item-id-456).NPM_TOKEN}',
+      login: '${op(My Database Login).password}',
+    },
+    { variableSources: [source] }
+  )
+  assert.is(config.linked, 'npm_xxx')
+  assert.is(config.login, 'login-secret')
+})
+
+/* Rejections (resolver called directly) */
+
+test('raw op:// in colon syntax is rejected with pointer to function syntax', async () => {
+  const source = createOnePasswordResolver({ execFile: fakeOp().execFile })
+  try {
+    await source.resolver('op:op://vault/item/field', {}, {}, vo('op:op://vault/item/field'))
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Use \$\{op\(op:\/\/vault\/item\/field\)\} for direct secret references/)
+  }
+})
+
+test('private link in colon syntax is rejected', async () => {
+  const source = createOnePasswordResolver({ execFile: fakeOp().execFile })
+  try {
+    await source.resolver('op:https://start.1password.com/open/i?i=x', {}, {}, vo('op:https://...'))
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /letters, numbers, and underscores|aliases/i)
+  }
+})
+
+test('public share link in function syntax is rejected', async () => {
+  const source = createOnePasswordResolver({ execFile: fakeOp().execFile })
+  try {
+    await source.resolver('op(https://share.1password.com/s#tok)', {}, {}, vo('op(...)'))
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Public 1Password share links are not supported/)
+  }
+})
+
+test('unknown alias names the missing ref', async () => {
+  const source = createOnePasswordResolver({ refs: {}, execFile: fakeOp().execFile })
+  try {
+    await source.resolver('op:npm', {}, {}, vo('op:npm'))
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Unknown 1Password alias "npm". Configure refs.npm/)
+  }
+})
+
+test('invalid alias key rejected at factory time', () => {
+  try {
+    createOnePasswordResolver({ refs: { 'npm.prod': 'x' } })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /letters, numbers, and underscores/)
+  }
+})
+
+/* Metadata */
+
+test('metadata records references but never secret values or URLs', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({
+    refs: {
+      npm: 'op://prod/npm/notesPlain',
+      linked: 'https://start.1password.com/open/i?a=ACCT&v=vault-id-123&i=item-id-456&h=my.1password.com',
+    },
+    execFile: fake.execFile,
+  })
+  await configorama({ a: '${op:npm.NPM_TOKEN}', b: '${op:linked.NPM_TOKEN}' }, { variableSources: [source] })
+  const metadata = source.collectMetadata()
+  assert.is(metadata.length, 2)
+  const serialized = JSON.stringify(metadata)
+  assert.is(serialized.includes('npm_xxx'), false)
+  assert.is(serialized.includes('s3cr3t'), false)
+  assert.is(serialized.includes('start.1password.com'), false)
+  assert.is(serialized.includes('ACCT'), false)
+  const linkEntry = metadata.find((entry) => entry.referenceKind === 'privateLink')
+  assert.is(linkEntry.item, 'item-id-456')
+  assert.is(linkEntry.vault, 'vault-id-123')
+  assert.is(linkEntry.sensitive, true)
+  assert.is(linkEntry.risk, 'remote_secret_read')
+})
+
+/* skipResolution */
+
+test('skipResolution returns placeholders and records skipped metadata', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({
+    refs: { npm: 'op://prod/npm/notesPlain' },
+    skipResolution: true,
+    execFile: fake.execFile,
+  })
+  const config = await configorama(
+    {
+      aliased: '${op:npm.NPM_TOKEN}',
+      direct: '${op(op://vault/item/field)}',
+      item: '${op(item-id-456).NPM_TOKEN}',
+    },
+    { variableSources: [source] }
+  )
+  assert.is(config.aliased, '[OP:alias:npm.NPM_TOKEN]')
+  assert.is(config.direct, '[OP:secretRef:op://vault/item/field]')
+  assert.is(config.item, '[OP:item:item-id-456:NPM_TOKEN]')
+  assert.is(fake.calls.length, 0)
+  assert.is(source.collectMetadata().every((entry) => entry.skipped === true), true)
+})
+
+/* Caching */
+
+test('cache prevents duplicate CLI calls for the same item and ref', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ refs: { npm: 'note-item' }, execFile: fake.execFile })
+  await configorama(
+    { a: '${op:npm.NPM_TOKEN}', b: '${op:npm.database.password}', c: '${op:npm}' },
+    { variableSources: [source] }
+  )
+  assert.is(fake.calls.length, 1)
+})
+
+test('failed calls are not cached and retry succeeds', async () => {
+  const fake = fakeOp({ failFirst: true })
+  const source = createOnePasswordResolver({ refs: { npm: 'note-item' }, execFile: fake.execFile })
+  try {
+    await source.resolver('op:npm.NPM_TOKEN', {}, {}, vo('op:npm.NPM_TOKEN'))
+    assert.unreachable('first call should fail')
+  } catch (err) {
+    assert.match(err.message, /could not be found/)
+  }
+  const value = await source.resolver('op:npm.NPM_TOKEN', {}, {}, vo('op:npm.NPM_TOKEN'))
+  assert.is(value, 'npm_xxx')
+  assert.is(fake.calls.length, 2)
+})
+
+test('clearCache clears caches and metadata', async () => {
+  const fake = fakeOp()
+  const source = createOnePasswordResolver({ refs: { npm: 'note-item' }, execFile: fake.execFile })
+  await source.resolver('op:npm.NPM_TOKEN', {}, {}, vo('op:npm.NPM_TOKEN'))
+  assert.is(source.collectMetadata().length, 1)
+  source.clearCache()
+  assert.is(source.collectMetadata().length, 0)
+  await source.resolver('op:npm.NPM_TOKEN', {}, {}, vo('op:npm.NPM_TOKEN'))
+  assert.is(fake.calls.length, 2)
+})
+
+/* Source contract */
+
+test('returned source carries sensitive metadata and sync contract', () => {
+  const source = createOnePasswordResolver({ refs: { npm: 'note-item' }, account: 'my' })
+  assert.is(source.type, 'op')
+  assert.is(source.source, 'remote')
+  assert.is(source.sensitive, true)
+  assert.is(source.risk, 'remote_secret_read')
+  assert.is(source.match instanceof RegExp, true)
+  assert.is(source.match.test('op:alias'), true)
+  assert.is(source.match.test('op(item)'), true)
+  assert.is(source.match.test('opt:stage'), false)
+  assert.is(typeof source.syncFactory, 'string')
+  assert.equal(source.syncOptions, { refs: { npm: 'note-item' }, account: 'my', configDir: undefined, skipResolution: false })
+})
+
+test.run()

--- a/plugins/onepassword/index.test.js
+++ b/plugins/onepassword/index.test.js
@@ -314,6 +314,53 @@ test('clearCache clears caches and metadata', async () => {
   assert.is(fake.calls.length, 2)
 })
 
+test('cold start serializes the first op call before parallel fan-out', async () => {
+  const calls = []
+  let releaseFirst
+  function execFile(cmd, args, opts, cb) {
+    calls.push(args[2])
+    if (calls.length === 1) {
+      releaseFirst = () => cb(null, JSON.stringify(items['note-item']), '')
+      return
+    }
+    cb(null, JSON.stringify(items['database-prod']), '')
+  }
+  const source = createOnePasswordResolver({ refs: { a: 'note-item', b: 'database-prod' }, execFile })
+
+  const first = source.resolver('op:a', {}, {}, vo('op:a'))
+  const second = source.resolver('op:b', {}, {}, vo('op:b'))
+
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  assert.is(calls.length, 1, 'second op call must wait for the first to settle')
+
+  releaseFirst()
+  const [firstValue, secondValue] = await Promise.all([first, second])
+  assert.is(calls.length, 2)
+  assert.is(firstValue, INI_NOTE)
+  assert.is(secondValue, 'db-secret')
+})
+
+test('queued calls still run when the cold-start call fails', async () => {
+  const calls = []
+  function execFile(cmd, args, opts, cb) {
+    calls.push(args[2])
+    if (calls.length === 1) {
+      const err = Object.assign(new Error('fail'), { code: 1 })
+      return cb(err, '', 'item not found')
+    }
+    cb(null, JSON.stringify(items['database-prod']), '')
+  }
+  const source = createOnePasswordResolver({ refs: { a: 'missing-item', b: 'database-prod' }, execFile })
+
+  const results = await Promise.allSettled([
+    source.resolver('op:a', {}, {}, vo('op:a')),
+    source.resolver('op:b', {}, {}, vo('op:b')),
+  ])
+  assert.is(results[0].status, 'rejected')
+  assert.is(results[1].status, 'fulfilled')
+  assert.is(results[1].value, 'db-secret')
+})
+
 /* Source contract */
 
 test('returned source carries sensitive metadata and sync contract', () => {

--- a/plugins/onepassword/index.test.js
+++ b/plugins/onepassword/index.test.js
@@ -314,7 +314,7 @@ test('returned source carries sensitive metadata and sync contract', () => {
   assert.is(source.match.test('op(item)'), true)
   assert.is(source.match.test('opt:stage'), false)
   assert.is(typeof source.syncFactory, 'string')
-  assert.equal(source.syncOptions, { refs: { npm: 'note-item' }, account: 'my', configDir: undefined, skipResolution: false })
+  assert.equal(source.syncOptions, { refs: { npm: 'note-item' }, account: 'my', configDir: undefined, opPath: undefined, skipResolution: false })
 })
 
 test.run()

--- a/plugins/onepassword/normalize.js
+++ b/plugins/onepassword/normalize.js
@@ -1,0 +1,128 @@
+/* Normalizes 1Password references into canonical secretRef/item/privateLink forms
+   Validates aliases, parses private item links, rejects public share links */
+
+const ALIAS_PATTERN = /^[A-Za-z0-9_]+$/
+const PRIVATE_LINK_PREFIXES = ['https://start.1password.com/open/i', 'onepassword://open/i']
+
+/**
+ * Validate an alias name from the refs config.
+ * Dots are reserved as the key path separator so they cannot appear in aliases.
+ * @param {string} alias - Alias name to validate
+ */
+function validateAliasName(alias) {
+  if (!ALIAS_PATTERN.test(alias)) {
+    throw new Error(`Invalid 1Password alias "${alias}". Aliases may contain only letters, numbers, and underscores.`)
+  }
+}
+
+/**
+ * Check whether a string is a private item link.
+ * @param {string} value - Candidate string
+ * @returns {boolean} True when the string is a private item link
+ */
+function isPrivateLink(value) {
+  return PRIVATE_LINK_PREFIXES.some((prefix) => value.startsWith(prefix))
+}
+
+/**
+ * Parse a "Copy Private Link" URL into item and vault IDs.
+ * The a (account) and h (host) params identify the account and are
+ * intentionally dropped; item + vault IDs are all op item get needs.
+ * @param {string} url - Private item link
+ * @returns {{kind: string, item: string, vault: string|undefined, warnings: Array<{code: string, message: string}>}} Normalized reference
+ */
+function parsePrivateLink(url) {
+  const queryIndex = url.indexOf('?')
+  const query = queryIndex === -1 ? '' : url.slice(queryIndex + 1)
+  const params = new URLSearchParams(query)
+  const item = params.get('i')
+  const vault = params.get('v')
+
+  if (!item) {
+    throw new Error('Invalid 1Password private link. Expected query parameter "i" with the item ID.')
+  }
+
+  const warnings = []
+  if (!vault) {
+    warnings.push({
+      level: 'warning',
+      code: 'op_private_link_missing_vault',
+      message: '1Password private link did not include a vault ID; service accounts and duplicate item names may require vault scoping.',
+    })
+  }
+
+  return { kind: 'privateLink', item, vault: vault || undefined, warnings }
+}
+
+/**
+ * Normalize a string or object ref value into a canonical reference.
+ * Accepted forms: op:// string, item name string, private link string,
+ * { item, vault, section, field }, { ref }, { url }.
+ * @param {string|object} value - Ref value from config or direct spec
+ * @returns {object} Normalized reference ({ kind: 'secretRef'|'item'|'privateLink', ... })
+ */
+function normalizeRefValue(value) {
+  if (typeof value === 'string') {
+    return normalizeStringRef(value)
+  }
+  if (value && typeof value === 'object') {
+    return normalizeObjectRef(value)
+  }
+  throw new Error(`Invalid 1Password reference. Expected a string or object, got ${typeof value}.`)
+}
+
+/**
+ * @param {string} value - String ref (secret ref, link, or item name)
+ * @returns {object} Normalized reference
+ */
+function normalizeStringRef(value) {
+  if (value.startsWith('op://')) {
+    return { kind: 'secretRef', ref: value }
+  }
+  if (isPrivateLink(value)) {
+    return parsePrivateLink(value)
+  }
+  if (/^https?:\/\/|^onepassword:\/\//.test(value)) {
+    if (value.includes('share.1password.com') || /1password\.com\/s#/.test(value)) {
+      throw new Error('Public 1Password share links are not supported. Use Copy Private Link or an op:// secret reference.')
+    }
+    throw new Error('Unrecognized 1Password link. Use Copy Private Link or an op:// secret reference.')
+  }
+  return { kind: 'item', item: value, vault: undefined, section: undefined, field: undefined }
+}
+
+/**
+ * @param {object} value - Object ref ({ item }, { ref }, or { url })
+ * @returns {object} Normalized reference
+ */
+function normalizeObjectRef(value) {
+  const specifiers = ['item', 'ref', 'url'].filter((key) => value[key] !== undefined)
+  if (specifiers.length !== 1) {
+    throw new Error('Invalid 1Password reference. Object refs must specify exactly one of "item", "ref", or "url".')
+  }
+
+  if (value.ref !== undefined) {
+    return normalizeStringRef(value.ref)
+  }
+  if (value.url !== undefined) {
+    const normalized = normalizeStringRef(value.url)
+    if (normalized.kind !== 'privateLink') {
+      throw new Error('Invalid 1Password reference. "url" must be a private item link.')
+    }
+    return normalized
+  }
+
+  if (value.section !== undefined && value.field === undefined) {
+    throw new Error('Invalid 1Password reference. "section" is only meaningful together with "field".')
+  }
+
+  return {
+    kind: 'item',
+    item: value.item,
+    vault: value.vault,
+    section: value.section,
+    field: value.field,
+  }
+}
+
+module.exports = { validateAliasName, normalizeRefValue, parsePrivateLink, isPrivateLink }

--- a/plugins/onepassword/normalize.test.js
+++ b/plugins/onepassword/normalize.test.js
@@ -1,0 +1,151 @@
+/* Tests for 1Password reference normalization
+   Covers alias validation, ref forms, private links, and share link rejection */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const { validateAliasName, normalizeRefValue, parsePrivateLink } = require('./normalize')
+
+const PRIVATE_LINK = 'https://start.1password.com/open/i?a=ACCT&v=vault-id-123&i=item-id-456&h=my.1password.com'
+const PRIVATE_LINK_APP = 'onepassword://open/i?a=ACCT&v=vault-id-123&i=item-id-456&h=my.1password.com'
+
+/* Alias validation */
+
+test('accepts alphanumeric and underscore aliases', () => {
+  validateAliasName('npm')
+  validateAliasName('data_base_2')
+  validateAliasName('UPPER')
+})
+
+test('rejects aliases with dots, hyphens, spaces, slashes', () => {
+  for (const bad of ['npm.prod', 'my-alias', 'a b', 'a/b', '']) {
+    try {
+      validateAliasName(bad)
+      assert.unreachable(`should reject "${bad}"`)
+    } catch (err) {
+      assert.match(err.message, /letters, numbers, and underscores/)
+    }
+  }
+})
+
+/* String ref forms */
+
+test('op:// string becomes secretRef', () => {
+  const ref = normalizeRefValue('op://prod/npm/notesPlain')
+  assert.equal(ref, { kind: 'secretRef', ref: 'op://prod/npm/notesPlain' })
+})
+
+test('plain string becomes item', () => {
+  const ref = normalizeRefValue('database-prod')
+  assert.is(ref.kind, 'item')
+  assert.is(ref.item, 'database-prod')
+  assert.is(ref.vault, undefined)
+  assert.is(ref.field, undefined)
+})
+
+test('https private link string becomes privateLink', () => {
+  const ref = normalizeRefValue(PRIVATE_LINK)
+  assert.is(ref.kind, 'privateLink')
+  assert.is(ref.item, 'item-id-456')
+  assert.is(ref.vault, 'vault-id-123')
+})
+
+test('onepassword:// private link string becomes privateLink', () => {
+  const ref = normalizeRefValue(PRIVATE_LINK_APP)
+  assert.is(ref.kind, 'privateLink')
+  assert.is(ref.item, 'item-id-456')
+  assert.is(ref.vault, 'vault-id-123')
+})
+
+test('normalized private link drops a, h, and raw URL', () => {
+  const ref = normalizeRefValue(PRIVATE_LINK)
+  const serialized = JSON.stringify(ref)
+  assert.is(serialized.includes('ACCT'), false)
+  assert.is(serialized.includes('my.1password.com'), false)
+  assert.is(serialized.includes('start.1password.com'), false)
+})
+
+/* Object ref forms */
+
+test('object with item, vault, section, field', () => {
+  const ref = normalizeRefValue({ item: 'GitHub', vault: 'development', section: 'credentials', field: 'personal_token' })
+  assert.equal(ref, { kind: 'item', item: 'GitHub', vault: 'development', section: 'credentials', field: 'personal_token' })
+})
+
+test('object with ref', () => {
+  const ref = normalizeRefValue({ ref: 'op://prod/item/field' })
+  assert.equal(ref, { kind: 'secretRef', ref: 'op://prod/item/field' })
+})
+
+test('object with url', () => {
+  const ref = normalizeRefValue({ url: PRIVATE_LINK })
+  assert.is(ref.kind, 'privateLink')
+  assert.is(ref.item, 'item-id-456')
+})
+
+test('object combining item and ref is rejected', () => {
+  try {
+    normalizeRefValue({ item: 'x', ref: 'op://a/b/c' })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /exactly one of/)
+  }
+})
+
+test('object with none of item, ref, url is rejected', () => {
+  try {
+    normalizeRefValue({ vault: 'prod' })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /exactly one of/)
+  }
+})
+
+test('section without field is rejected', () => {
+  try {
+    normalizeRefValue({ item: 'x', section: 'creds' })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /section/)
+  }
+})
+
+/* Private link parsing */
+
+test('missing i throws invalid private link', () => {
+  try {
+    parsePrivateLink('https://start.1password.com/open/i?a=ACCT&v=vault-id')
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Expected query parameter "i"/)
+  }
+})
+
+test('missing v allows fetch and attaches warning', () => {
+  const ref = parsePrivateLink('https://start.1password.com/open/i?a=ACCT&i=item-id-456')
+  assert.is(ref.item, 'item-id-456')
+  assert.is(ref.vault, undefined)
+  assert.is(ref.warnings.length, 1)
+  assert.is(ref.warnings[0].code, 'op_private_link_missing_vault')
+})
+
+/* Public share links */
+
+test('public share links are rejected', () => {
+  try {
+    normalizeRefValue('https://share.1password.com/s#sometoken')
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Public 1Password share links are not supported/)
+    assert.is(err.message.includes('sometoken'), false)
+  }
+})
+
+test('unrecognized 1Password URLs are rejected, not treated as item names', () => {
+  try {
+    normalizeRefValue('https://example.com/whatever')
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Unrecognized/)
+  }
+})
+
+test.run()

--- a/plugins/onepassword/op-cli.js
+++ b/plugins/onepassword/op-cli.js
@@ -9,11 +9,12 @@ const NOT_FOUND_PATTERN = /isn'?t an? (item|vault)|not found|no item|no vault|do
  * Run the op binary with the given args.
  * No `command -v op` preflight: translating ENOENT is the existence check.
  * @param {string[]} args - CLI arguments
- * @param {object} [options] - { execFile, account, configDir, subject }
+ * @param {object} [options] - { execFile, opPath, account, configDir, subject }
  * @returns {Promise<string>} stdout
  */
 function runOp(args, options = {}) {
   const execFile = options.execFile || childProcess.execFile
+  const binary = options.opPath || 'op'
   const finalArgs = args.slice()
   if (options.account) {
     finalArgs.push('--account', options.account)
@@ -23,7 +24,7 @@ function runOp(args, options = {}) {
   }
 
   return new Promise((resolve, reject) => {
-    execFile('op', finalArgs, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+    execFile(binary, finalArgs, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
       if (err) {
         return reject(translateError(err, stderr, options.subject))
       }
@@ -64,6 +65,7 @@ function translateError(err, stderr, subject) {
 function readSecretRef(ref, options = {}) {
   return runOp(['read', '--no-newline', ref], {
     execFile: options.execFile,
+    opPath: options.opPath,
     account: options.account,
     configDir: options.configDir,
     subject: ref,
@@ -84,6 +86,7 @@ async function getItem(spec, options = {}) {
   }
   const stdout = await runOp(args, {
     execFile: options.execFile,
+    opPath: options.opPath,
     account: options.account,
     configDir: options.configDir,
     subject: spec,

--- a/plugins/onepassword/op-cli.js
+++ b/plugins/onepassword/op-cli.js
@@ -57,6 +57,20 @@ function translateError(err, stderr, subject) {
 }
 
 /**
+ * Reject config-controlled values that would be parsed as an op flag.
+ * execFile takes no shell, so this is not command injection - but a
+ * leading "-" turns a positional/vault value into an option that changes
+ * op's behavior. Secret refs are exempt: they always start with "op://".
+ * @param {string} value - Value destined for the op argument list
+ * @param {string} label - Human label for the error message
+ */
+function assertNotFlag(value, label) {
+  if (typeof value === 'string' && value.startsWith('-')) {
+    throw new Error(`Invalid 1Password ${label} "${value}": ${label} cannot start with "-" (it would be read as an op flag). Use the item ID or an op:// secret reference.`)
+  }
+}
+
+/**
  * Read a secret reference with op read.
  * @param {string} ref - op://vault/item/field reference
  * @param {object} [options] - { execFile, account, configDir }
@@ -80,8 +94,10 @@ function readSecretRef(ref, options = {}) {
  * @returns {Promise<object>} Parsed item JSON
  */
 async function getItem(spec, options = {}) {
+  assertNotFlag(spec, 'item')
   const args = ['item', 'get', spec, '--format', 'json', '--reveal']
   if (options.vault) {
+    assertNotFlag(options.vault, 'vault')
     args.push('--vault', options.vault)
   }
   const stdout = await runOp(args, {

--- a/plugins/onepassword/op-cli.js
+++ b/plugins/onepassword/op-cli.js
@@ -1,0 +1,98 @@
+/* Executes the 1Password CLI with execFile and sanitized error translation
+   Never logs stdout/stderr; never passes resolved secret values as arguments */
+const childProcess = require('child_process')
+
+const AUTH_ERROR_PATTERN = /sign ?in|session|authoriz|authenticat|not currently signed|locked|service account token/i
+const NOT_FOUND_PATTERN = /isn'?t an? (item|vault)|not found|no item|no vault|doesn'?t exist|more than one item/i
+
+/**
+ * Run the op binary with the given args.
+ * No `command -v op` preflight: translating ENOENT is the existence check.
+ * @param {string[]} args - CLI arguments
+ * @param {object} [options] - { execFile, account, configDir, subject }
+ * @returns {Promise<string>} stdout
+ */
+function runOp(args, options = {}) {
+  const execFile = options.execFile || childProcess.execFile
+  const finalArgs = args.slice()
+  if (options.account) {
+    finalArgs.push('--account', options.account)
+  }
+  if (options.configDir) {
+    finalArgs.push('--config', options.configDir)
+  }
+
+  return new Promise((resolve, reject) => {
+    execFile('op', finalArgs, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout, stderr) => {
+      if (err) {
+        return reject(translateError(err, stderr, options.subject))
+      }
+      resolve(stdout)
+    })
+  })
+}
+
+/**
+ * Translate op failures into sanitized, actionable errors.
+ * stderr is inspected for classification but never included in messages.
+ * @param {Error & {code?: string|number}} err - execFile error
+ * @param {string} stderr - Captured stderr (classification only)
+ * @param {string} [subject] - Item/ref identifier already present in user config
+ * @returns {Error} Sanitized error
+ */
+function translateError(err, stderr, subject) {
+  if (err.code === 'ENOENT') {
+    return new Error('1Password CLI "op" was not found on PATH. Install 1Password CLI or remove the op resolver.')
+  }
+  const detail = String(stderr || err.message || '')
+  if (AUTH_ERROR_PATTERN.test(detail)) {
+    return new Error('1Password CLI could not read the item. Run op signin, unlock 1Password app integration, or configure OP_SERVICE_ACCOUNT_TOKEN.')
+  }
+  if (NOT_FOUND_PATTERN.test(detail)) {
+    const what = subject ? `"${subject}"` : 'the requested item, vault, or field'
+    return new Error(`1Password item, vault, or field could not be found (${what}).`)
+  }
+  return new Error('1Password CLI command failed.')
+}
+
+/**
+ * Read a secret reference with op read.
+ * @param {string} ref - op://vault/item/field reference
+ * @param {object} [options] - { execFile, account, configDir }
+ * @returns {Promise<string>} Secret value
+ */
+function readSecretRef(ref, options = {}) {
+  return runOp(['read', '--no-newline', ref], {
+    execFile: options.execFile,
+    account: options.account,
+    configDir: options.configDir,
+    subject: ref,
+  })
+}
+
+/**
+ * Fetch an item as JSON with op item get.
+ * --reveal is required to include concealed field values in the JSON.
+ * @param {string} spec - Item ID or item name
+ * @param {object} [options] - { execFile, account, configDir, vault }
+ * @returns {Promise<object>} Parsed item JSON
+ */
+async function getItem(spec, options = {}) {
+  const args = ['item', 'get', spec, '--format', 'json', '--reveal']
+  if (options.vault) {
+    args.push('--vault', options.vault)
+  }
+  const stdout = await runOp(args, {
+    execFile: options.execFile,
+    account: options.account,
+    configDir: options.configDir,
+    subject: spec,
+  })
+  try {
+    return JSON.parse(stdout)
+  } catch (err) {
+    throw new Error(`Could not parse 1Password CLI output as JSON for item "${spec}".`)
+  }
+}
+
+module.exports = { runOp, readSecretRef, getItem }

--- a/plugins/onepassword/op-cli.test.js
+++ b/plugins/onepassword/op-cli.test.js
@@ -1,0 +1,109 @@
+/* Tests for the op CLI wrapper
+   Uses injected execFile; never calls the real 1Password CLI */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const { readSecretRef, getItem } = require('./op-cli')
+
+/**
+ * Build a fake execFile capturing calls and returning canned results
+ * @param {object} behavior - { stdout, error, stderr }
+ * @returns {{execFile: Function, calls: Array}} Fake and its call log
+ */
+function fakeExecFile(behavior = {}) {
+  const calls = []
+  function execFile(cmd, args, opts, cb) {
+    calls.push({ cmd, args })
+    if (behavior.error) {
+      const err = Object.assign(new Error(behavior.error.message || 'fail'), behavior.error)
+      err.stderr = behavior.stderr || ''
+      return cb(err, '', behavior.stderr || '')
+    }
+    cb(null, behavior.stdout || '', '')
+  }
+  return { execFile, calls }
+}
+
+test('readSecretRef calls op read --no-newline <ref>', async () => {
+  const fake = fakeExecFile({ stdout: 'secret-value' })
+  const value = await readSecretRef('op://vault/item/field', { execFile: fake.execFile })
+  assert.is(value, 'secret-value')
+  assert.is(fake.calls[0].cmd, 'op')
+  assert.equal(fake.calls[0].args, ['read', '--no-newline', 'op://vault/item/field'])
+})
+
+test('getItem calls op item get with json + reveal and parses stdout', async () => {
+  const fake = fakeExecFile({ stdout: '{"id":"item-1","fields":[]}' })
+  const item = await getItem('item-1', { execFile: fake.execFile })
+  assert.equal(item, { id: 'item-1', fields: [] })
+  assert.equal(fake.calls[0].args, ['item', 'get', 'item-1', '--format', 'json', '--reveal'])
+})
+
+test('vault, account, and configDir become CLI flags', async () => {
+  const fake = fakeExecFile({ stdout: '{}' })
+  await getItem('item-1', { execFile: fake.execFile, vault: 'vault-9', account: 'my', configDir: '/op/config' })
+  assert.equal(fake.calls[0].args, [
+    'item', 'get', 'item-1', '--format', 'json', '--reveal',
+    '--vault', 'vault-9', '--account', 'my', '--config', '/op/config',
+  ])
+})
+
+test('readSecretRef passes account and configDir but never vault', async () => {
+  const fake = fakeExecFile({ stdout: 'v' })
+  await readSecretRef('op://a/b/c', { execFile: fake.execFile, account: 'my', configDir: '/op/config', vault: 'ignored' })
+  assert.equal(fake.calls[0].args, ['read', '--no-newline', 'op://a/b/c', '--account', 'my', '--config', '/op/config'])
+})
+
+test('ENOENT becomes missing-CLI error', async () => {
+  const fake = fakeExecFile({ error: { code: 'ENOENT' } })
+  try {
+    await readSecretRef('op://a/b/c', { execFile: fake.execFile })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /1Password CLI "op" was not found on PATH/)
+  }
+})
+
+test('signin-ish failure becomes sanitized auth error', async () => {
+  const fake = fakeExecFile({ error: { code: 1 }, stderr: '[ERROR] account is not signed in, run `op signin`, secret-hint-xyz' })
+  try {
+    await getItem('item-1', { execFile: fake.execFile })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Run op signin, unlock 1Password app integration, or configure OP_SERVICE_ACCOUNT_TOKEN/)
+    assert.is(err.message.includes('secret-hint-xyz'), false)
+  }
+})
+
+test('not-found failure becomes sanitized not-found error', async () => {
+  const fake = fakeExecFile({ error: { code: 1 }, stderr: '[ERROR] "item-1" isn\'t an item in the "prod" vault, uuid-abc' })
+  try {
+    await getItem('item-1', { execFile: fake.execFile })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /could not be found/)
+    assert.is(err.message.includes('uuid-abc'), false)
+  }
+})
+
+test('generic failure is sanitized without stderr', async () => {
+  const fake = fakeExecFile({ error: { code: 1 }, stderr: 'weird internal failure with secret-material' })
+  try {
+    await getItem('item-1', { execFile: fake.execFile })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.is(err.message.includes('secret-material'), false)
+  }
+})
+
+test('malformed JSON from item get becomes sanitized parse error', async () => {
+  const fake = fakeExecFile({ stdout: 'not-json secret-body' })
+  try {
+    await getItem('item-1', { execFile: fake.execFile })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Could not parse 1Password CLI output as JSON/)
+    assert.is(err.message.includes('secret-body'), false)
+  }
+})
+
+test.run()

--- a/plugins/onepassword/op-cli.test.js
+++ b/plugins/onepassword/op-cli.test.js
@@ -95,6 +95,29 @@ test('generic failure is sanitized without stderr', async () => {
   }
 })
 
+test('item spec starting with dash is rejected before spawning op', async () => {
+  const fake = fakeExecFile({ stdout: '{}' })
+  try {
+    await getItem('--help', { execFile: fake.execFile })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /cannot start with "-"/)
+    assert.is(err.message.includes('op flag'), true)
+  }
+  assert.is(fake.calls.length, 0, 'op must not be spawned for a flag-like spec')
+})
+
+test('vault starting with dash is rejected before spawning op', async () => {
+  const fake = fakeExecFile({ stdout: '{}' })
+  try {
+    await getItem('item-1', { execFile: fake.execFile, vault: '--config' })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /cannot start with "-"/)
+  }
+  assert.is(fake.calls.length, 0)
+})
+
 test('malformed JSON from item get becomes sanitized parse error', async () => {
   const fake = fakeExecFile({ stdout: 'not-json secret-body' })
   try {

--- a/plugins/onepassword/package.json
+++ b/plugins/onepassword/package.json
@@ -4,7 +4,7 @@
   "description": "1Password variable source plugin for configorama",
   "main": "index.js",
   "scripts": {
-    "test": "node parser.test.js && node op-cli.test.js && node index.test.js"
+    "test": "node parser.test.js && node normalize.test.js && node op-cli.test.js && node fields.test.js && node index.test.js && node smoke.test.js"
   },
   "keywords": [
     "configorama",

--- a/plugins/onepassword/package.json
+++ b/plugins/onepassword/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "configorama-onepassword",
+  "version": "0.1.0",
+  "description": "1Password variable source plugin for configorama",
+  "main": "index.js",
+  "scripts": {
+    "test": "node parser.test.js && node op-cli.test.js && node index.test.js"
+  },
+  "keywords": [
+    "configorama",
+    "1password",
+    "secrets"
+  ],
+  "license": "MIT"
+}

--- a/plugins/onepassword/parser.js
+++ b/plugins/onepassword/parser.js
@@ -1,0 +1,70 @@
+/* Parses 1Password field text as INI/dotenv for key path reads
+   Raw field text is only parsed when a config reference asks for a key path */
+const ini = require('ini')
+
+/**
+ * Restore ini module coercions so secret values stay strings.
+ * The ini parser coerces true/false/null which corrupts literal
+ * secret text like FLAG=true.
+ * @param {*} value - Parsed ini node
+ * @returns {*} Node with primitives restored to strings
+ */
+function stringifyPrimitives(value) {
+  if (value === true) return 'true'
+  if (value === false) return 'false'
+  if (value === null) return 'null'
+  if (typeof value === 'object') {
+    const result = {}
+    for (const key of Object.keys(value)) {
+      result[key] = stringifyPrimitives(value[key])
+    }
+    return result
+  }
+  return value
+}
+
+/**
+ * Parse structured secret text.
+ * V1 supports INI/dotenv only. Future format detection order:
+ * 1. explicit format option on the ref
+ * 2. JSON if the trimmed value starts with { or [
+ * 3. YAML only with proof it is not confused with INI
+ * 4. INI fallback
+ * @param {string} value - Raw field text
+ * @param {object} [options] - Reserved for future format selection
+ * @returns {object} Parsed key/value structure
+ */
+function parseStructuredSecret(value, options = {}) {
+  let parsed
+  try {
+    parsed = ini.parse(value)
+  } catch (err) {
+    throw new Error(`Could not parse 1Password field "${options.fieldName || 'value'}" as INI/dotenv.`)
+  }
+  return stringifyPrimitives(parsed)
+}
+
+/**
+ * Read a dot-separated key path from a parsed structure.
+ * Error messages never include secret values.
+ * @param {object} parsed - Result of parseStructuredSecret
+ * @param {string} keyPath - Dot-separated path, e.g. "database.password"
+ * @param {string} fieldName - 1Password field name for error messages
+ * @returns {string} Selected value
+ */
+function getKeyPath(parsed, keyPath, fieldName) {
+  const segments = keyPath.split('.')
+  let current = parsed
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object' || !(segment in current)) {
+      throw new Error(`Key path "${keyPath}" was not found in 1Password field "${fieldName}".`)
+    }
+    current = current[segment]
+  }
+  if (typeof current === 'object') {
+    throw new Error(`Key path "${keyPath}" was not found in 1Password field "${fieldName}".`)
+  }
+  return current
+}
+
+module.exports = { parseStructuredSecret, getKeyPath }

--- a/plugins/onepassword/parser.test.js
+++ b/plugins/onepassword/parser.test.js
@@ -1,0 +1,73 @@
+/* Tests for 1Password structured value parser
+   Verifies INI/dotenv key path reads and raw value rules */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const { parseStructuredSecret, getKeyPath } = require('./parser')
+
+const INI_FIXTURE = `# npm automation token
+NPM_TOKEN=npm_xxx
+
+[database]
+password=s3cr3t
+`
+
+test('parses KEY=value', () => {
+  const parsed = parseStructuredSecret('NPM_TOKEN=npm_xxx')
+  assert.is(parsed.NPM_TOKEN, 'npm_xxx')
+})
+
+test('ignores # comments', () => {
+  const parsed = parseStructuredSecret(INI_FIXTURE)
+  assert.is(parsed.NPM_TOKEN, 'npm_xxx')
+  assert.is(Object.keys(parsed).includes('# npm automation token'), false)
+})
+
+test('ignores ; comments', () => {
+  const parsed = parseStructuredSecret('; a comment\nKEY=value')
+  assert.is(parsed.KEY, 'value')
+})
+
+test('supports section paths', () => {
+  const parsed = parseStructuredSecret(INI_FIXTURE)
+  assert.is(getKeyPath(parsed, 'database.password', 'notesPlain'), 's3cr3t')
+})
+
+test('returns top-level keys via getKeyPath', () => {
+  const parsed = parseStructuredSecret(INI_FIXTURE)
+  assert.is(getKeyPath(parsed, 'NPM_TOKEN', 'notesPlain'), 'npm_xxx')
+})
+
+test('errors on missing key with field name and no secret content', () => {
+  const parsed = parseStructuredSecret(INI_FIXTURE)
+  try {
+    getKeyPath(parsed, 'MISSING_KEY', 'notesPlain')
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Key path "MISSING_KEY" was not found in 1Password field "notesPlain"/)
+    assert.is(err.message.includes('npm_xxx'), false)
+    assert.is(err.message.includes('s3cr3t'), false)
+  }
+})
+
+test('preserves empty string values', () => {
+  const parsed = parseStructuredSecret('EMPTY=\nOTHER=x')
+  assert.is(getKeyPath(parsed, 'EMPTY', 'notesPlain'), '')
+})
+
+test('values containing = are not truncated', () => {
+  const parsed = parseStructuredSecret('TOKEN=abc==def=')
+  assert.is(parsed.TOKEN, 'abc==def=')
+})
+
+test('boolean-like values stay strings', () => {
+  const parsed = parseStructuredSecret('FLAG=true\nOFF=false')
+  assert.is(getKeyPath(parsed, 'FLAG', 'notesPlain'), 'true')
+  assert.is(getKeyPath(parsed, 'OFF', 'notesPlain'), 'false')
+})
+
+test('quoted values keep dotenv semantics (quotes stripped)', () => {
+  const parsed = parseStructuredSecret('KEY="quoted value"')
+  assert.is(parsed.KEY, 'quoted value')
+})
+
+test.run()

--- a/plugins/onepassword/smoke.test.js
+++ b/plugins/onepassword/smoke.test.js
@@ -1,0 +1,22 @@
+/* Optional real-CLI smoke test for the 1Password plugin
+   Runs only with CONFIGORAMA_OP_E2E=1 and CONFIGORAMA_OP_TEST_REF set */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const { readSecretRef } = require('./op-cli')
+
+const enabled = process.env.CONFIGORAMA_OP_E2E === '1' && process.env.CONFIGORAMA_OP_TEST_REF
+
+if (!enabled) {
+  test('1Password smoke test skipped (set CONFIGORAMA_OP_E2E=1 and CONFIGORAMA_OP_TEST_REF=op://... to enable)', () => {
+    assert.ok(true)
+  })
+} else {
+  test('op read resolves a non-empty value through the real CLI', async () => {
+    const value = await readSecretRef(process.env.CONFIGORAMA_OP_TEST_REF)
+    // Never print the value - assert on shape only
+    assert.type(value, 'string')
+    assert.ok(value.length > 0, 'resolved value should be non-empty')
+  })
+}
+
+test.run()

--- a/plugins/onepassword/sync-factory.js
+++ b/plugins/onepassword/sync-factory.js
@@ -1,0 +1,11 @@
+/* Factory entry for configorama.sync() workers
+   Rebuilds the 1Password resolver from JSON-serializable options inside the sync worker */
+const createOnePasswordResolver = require('./index')
+
+/**
+ * @param {object} options - JSON-round-tripped syncOptions ({ refs, account, configDir, skipResolution })
+ * @returns {object} Variable source
+ */
+module.exports = function createSyncOnePasswordResolver(options = {}) {
+  return createOnePasswordResolver(options)
+}

--- a/plugins/onepassword/sync-factory.js
+++ b/plugins/onepassword/sync-factory.js
@@ -7,5 +7,9 @@ const createOnePasswordResolver = require('./index')
  * @returns {object} Variable source
  */
 module.exports = function createSyncOnePasswordResolver(options = {}) {
-  return createOnePasswordResolver(options)
+  if (options.hasInjectedExecFile) {
+    throw new Error('1Password resolver options are not serializable for sync usage. Remove the injected execFile or use the async API.')
+  }
+  const { hasInjectedExecFile, ...factoryOptions } = options
+  return createOnePasswordResolver(factoryOptions)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -163,7 +163,14 @@ module.exports.audit = async (configPathOrObject, settings = {}) => {
   const requirements = buildConfigRequirements(analysis)
   const introspection = buildIntrospection(analysis, { requirements })
   const customResolvers = Array.isArray(settings.variableSources)
-    ? settings.variableSources.map(source => source.type).filter(Boolean)
+    ? settings.variableSources
+      .filter(source => source.type)
+      .map(source => ({
+        type: source.type,
+        sensitive: source.sensitive,
+        risk: source.risk,
+        description: source.description,
+      }))
     : []
   const originalConfig = analysis.originalConfig || {}
   return buildAuditReport(introspection, {

--- a/src/sync.js
+++ b/src/sync.js
@@ -9,6 +9,21 @@ const enrichMetadata = require('./utils/parsing/enrichMetadata')
  */
 module.exports = function configoramaSync(variableSources = []) {
   const customVariableSources = variableSources.map((varSrc) => {
+    /* Plugin factories: match/resolver do not survive the JSON trip through
+       sync-rpc, so plugins carry a syncFactory path + JSON syncOptions and
+       the real source is rebuilt here inside the worker process */
+    if (varSrc.syncFactory) {
+      const factoryPath = getFullPath(varSrc.syncFactory)
+      if (!fs.existsSync(factoryPath)) {
+        throw new Error(`Sync factory missing. Can't find ${factoryPath}`)
+      }
+      const createSource = require(factoryPath)
+      if (typeof createSource !== 'function') {
+        throw new Error(`Sync factory must export a function. Check ${factoryPath}`)
+      }
+      return createSource(varSrc.syncOptions || {})
+    }
+
     if (!varSrc.match || typeof varSrc.match !== 'string') {
       throw new Error('Variable source must be string for .sync usage')
     }
@@ -66,6 +81,18 @@ module.exports = function configoramaSync(variableSources = []) {
         options,
         instance.variableTypes
       )
+
+      /* Collect custom metadata from worker-side sources, mirroring the
+         collectMetadata loop the async API runs in src/index.js */
+      for (const source of customVariableSources) {
+        if (typeof source.collectMetadata === 'function') {
+          const customData = source.collectMetadata()
+          if (customData !== undefined && customData !== null) {
+            const metadataKey = source.metadataKey || `${source.type}References`
+            enrichedMetadata[metadataKey] = customData
+          }
+        }
+      }
 
       return {
         variableSyntax: instance.variableSyntax,

--- a/src/utils/introspection/audit.js
+++ b/src/utils/introspection/audit.js
@@ -41,15 +41,11 @@ function buildAuditReport(introspection, options = {}) {
   }
 
   if (options.customResolvers && options.customResolvers.length) {
-    for (const resolver of options.customResolvers.slice().sort()) {
-      findings.push({
-        id: `customResolver:${resolver}`,
-        severity: 'high',
-        risk: 'custom_extension',
-        kind: 'source',
-        variableType: resolver,
-        message: `Custom resolver "${resolver}" can execute user-provided code.`,
-      })
+    const sorted = options.customResolvers.slice().sort((a, b) => {
+      return String(a.type || a).localeCompare(String(b.type || b))
+    })
+    for (const resolver of sorted) {
+      findings.push(customResolverFinding(resolver))
     }
   }
 
@@ -67,6 +63,40 @@ function buildAuditReport(introspection, options = {}) {
       info: findings.filter(finding => finding.severity === 'info').length,
       total: findings.length,
     }
+  }
+}
+
+/**
+ * Build the audit finding for one custom resolver.
+ * Resolvers that self-describe as sensitive/risky get a specific finding
+ * instead of the generic custom_extension one - never both.
+ * @param {string|{type: string, sensitive?: boolean, risk?: string, description?: string}} resolver
+ * @returns {object} Audit finding
+ */
+function customResolverFinding(resolver) {
+  const source = typeof resolver === 'string' ? { type: resolver } : resolver
+  const { type, sensitive, risk, description } = source
+
+  if (sensitive === true || risk) {
+    const finding = {
+      id: `customResolver:${type}`,
+      severity: 'high',
+      risk: risk || 'custom_extension',
+      kind: 'source',
+      variableType: type,
+      message: `Custom resolver "${type}" reads secret values.${description ? ` ${description}.` : ''}`,
+    }
+    if (sensitive === true) finding.sensitive = true
+    return finding
+  }
+
+  return {
+    id: `customResolver:${type}`,
+    severity: 'high',
+    risk: 'custom_extension',
+    kind: 'source',
+    variableType: type,
+    message: `Custom resolver "${type}" can execute user-provided code.`,
   }
 }
 

--- a/tests/onepassword/bin/op
+++ b/tests/onepassword/bin/op
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fake 1Password CLI for configorama sync e2e tests
+# Serves fixture data for `op read` and `op item get`
+
+if [ "$1" = "read" ]; then
+  printf '# npm automation token\nNPM_TOKEN=npm_xxx\n\n[database]\npassword=s3cr3t\n'
+  exit 0
+fi
+
+if [ "$1" = "item" ] && [ "$2" = "get" ]; then
+  cat "$(dirname "$0")/../item-fixture.json"
+  exit 0
+fi
+
+echo "[ERROR] unsupported fake op invocation: $*" >&2
+exit 1

--- a/tests/onepassword/config.yml
+++ b/tests/onepassword/config.yml
@@ -1,0 +1,3 @@
+token: ${op:npm.NPM_TOKEN}
+dbPassword: ${op:npm.database.password}
+password: ${op:db}

--- a/tests/onepassword/item-fixture.json
+++ b/tests/onepassword/item-fixture.json
@@ -1,0 +1,8 @@
+{
+  "id": "database-prod",
+  "title": "database-prod",
+  "fields": [
+    { "id": "username", "type": "STRING", "purpose": "USERNAME", "label": "username", "value": "admin" },
+    { "id": "password", "type": "CONCEALED", "purpose": "PASSWORD", "label": "password", "value": "db-secret" }
+  ]
+}

--- a/tests/onepassword/onepassword-audit.test.js
+++ b/tests/onepassword/onepassword-audit.test.js
@@ -1,0 +1,81 @@
+/* eslint-disable no-template-curly-in-string */
+/* Audit and safe-mode integration tests for the 1Password plugin
+   Proves risk reporting without fetching and blocking during resolution */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const configorama = require('../../src')
+const createOnePasswordResolver = require('../../plugins/onepassword')
+
+/**
+ * execFile stub that records calls; audit paths must never reach it
+ * @returns {{execFile: Function, calls: Array}} Stub and call log
+ */
+function trackingExecFile() {
+  const calls = []
+  function execFile(cmd, args, opts, cb) {
+    calls.push({ cmd, args })
+    cb(null, '', '')
+  }
+  return { execFile, calls }
+}
+
+test('audit reports op as high-risk remote_secret_read without fetching', async () => {
+  const fake = trackingExecFile()
+  const source = createOnePasswordResolver({
+    refs: { npm: 'op://prod/npm/notesPlain' },
+    execFile: fake.execFile,
+  })
+  const report = await configorama.audit(
+    { token: '${op:npm.NPM_TOKEN}' },
+    { variableSources: [source] }
+  )
+
+  const finding = report.findings.find((entry) => entry.id === 'customResolver:op')
+  assert.ok(finding)
+  assert.is(finding.severity, 'high')
+  assert.is(finding.risk, 'remote_secret_read')
+  assert.is(finding.sensitive, true)
+  assert.match(finding.message, /1Password/)
+  assert.is(fake.calls.length, 0)
+})
+
+test('no generic custom_extension double-report for op', async () => {
+  const source = createOnePasswordResolver({ refs: {} })
+  const report = await configorama.audit({ plain: 'value' }, { variableSources: [source] })
+  const findings = report.findings.filter((entry) => entry.id === 'customResolver:op')
+  assert.is(findings.length, 1)
+  assert.is(findings[0].risk, 'remote_secret_read')
+})
+
+test('safe mode blocks op resolution by default', async () => {
+  const fake = trackingExecFile()
+  const source = createOnePasswordResolver({
+    refs: { npm: 'op://prod/npm/notesPlain' },
+    execFile: fake.execFile,
+  })
+  let caught
+  try {
+    await configorama({ token: '${op:npm.NPM_TOKEN}' }, { safeMode: true, variableSources: [source] })
+  } catch (err) {
+    caught = err
+  }
+  assert.ok(caught)
+  assert.is(caught.code, 'blocked_by_safe_mode')
+  assert.is(fake.calls.length, 0)
+})
+
+test('introspect registers the plugin without resolving secrets', async () => {
+  const fake = trackingExecFile()
+  const source = createOnePasswordResolver({
+    refs: { npm: 'op://prod/npm/notesPlain' },
+    execFile: fake.execFile,
+  })
+  const introspection = await configorama.introspect(
+    { token: '${op:npm.NPM_TOKEN}' },
+    { variableSources: [source] }
+  )
+  assert.ok(introspection)
+  assert.is(fake.calls.length, 0)
+})
+
+test.run()

--- a/tests/onepassword/onepassword-sync.test.js
+++ b/tests/onepassword/onepassword-sync.test.js
@@ -1,5 +1,5 @@
 /* Sync e2e tests for the 1Password plugin through configorama.sync()
-   Uses a fake op executable on PATH; the sync worker spawns it for real */
+   Uses a fake op executable via opPath; the sync worker spawns it for real */
 const { test } = require('uvu')
 const assert = require('uvu/assert')
 const path = require('path')
@@ -7,25 +7,20 @@ const configorama = require('../../src')
 const createOnePasswordResolver = require('../../plugins/onepassword')
 
 const yamlFile = path.join(__dirname, 'config.yml')
-const fakeBinDir = path.join(__dirname, 'bin')
-const originalPath = process.env.PATH
+// opPath (not a PATH shim): sync-rpc spawns one worker per process at the
+// first .sync() call anywhere in the suite, so PATH changes made in this
+// file never reach an already-running worker. opPath is serializable and
+// crosses the JSON boundary into the worker.
+const fakeOpPath = path.join(__dirname, 'bin', 'op')
 
 const refs = {
   npm: 'op://prod/npm/notesPlain',
   db: 'database-prod',
 }
 
-test.before(() => {
-  process.env.PATH = `${fakeBinDir}${path.delimiter}${originalPath}`
-})
-
-test.after(() => {
-  process.env.PATH = originalPath
-})
-
 test('configorama.sync resolves op values through syncFactory', () => {
   const config = configorama.sync(yamlFile, {
-    variableSources: [createOnePasswordResolver({ refs })],
+    variableSources: [createOnePasswordResolver({ refs, opPath: fakeOpPath })],
   })
   assert.is(config.token, 'npm_xxx')
   assert.is(config.dbPassword, 's3cr3t')
@@ -34,10 +29,10 @@ test('configorama.sync resolves op values through syncFactory', () => {
 
 test('sync result equals async result for the same fake op', async () => {
   const syncConfig = configorama.sync(yamlFile, {
-    variableSources: [createOnePasswordResolver({ refs })],
+    variableSources: [createOnePasswordResolver({ refs, opPath: fakeOpPath })],
   })
   const asyncConfig = await configorama(yamlFile, {
-    variableSources: [createOnePasswordResolver({ refs })],
+    variableSources: [createOnePasswordResolver({ refs, opPath: fakeOpPath })],
   })
   assert.equal(syncConfig, asyncConfig)
 })
@@ -45,7 +40,7 @@ test('sync result equals async result for the same fake op', async () => {
 test('sync returnMetadata surfaces opReferences from the worker', () => {
   const result = configorama.sync(yamlFile, {
     returnMetadata: true,
-    variableSources: [createOnePasswordResolver({ refs })],
+    variableSources: [createOnePasswordResolver({ refs, opPath: fakeOpPath })],
   })
   assert.is(result.config.token, 'npm_xxx')
   assert.ok(Array.isArray(result.metadata.opReferences))

--- a/tests/onepassword/onepassword-sync.test.js
+++ b/tests/onepassword/onepassword-sync.test.js
@@ -1,0 +1,68 @@
+/* Sync e2e tests for the 1Password plugin through configorama.sync()
+   Uses a fake op executable on PATH; the sync worker spawns it for real */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const path = require('path')
+const configorama = require('../../src')
+const createOnePasswordResolver = require('../../plugins/onepassword')
+
+const yamlFile = path.join(__dirname, 'config.yml')
+const fakeBinDir = path.join(__dirname, 'bin')
+const originalPath = process.env.PATH
+
+const refs = {
+  npm: 'op://prod/npm/notesPlain',
+  db: 'database-prod',
+}
+
+test.before(() => {
+  process.env.PATH = `${fakeBinDir}${path.delimiter}${originalPath}`
+})
+
+test.after(() => {
+  process.env.PATH = originalPath
+})
+
+test('configorama.sync resolves op values through syncFactory', () => {
+  const config = configorama.sync(yamlFile, {
+    variableSources: [createOnePasswordResolver({ refs })],
+  })
+  assert.is(config.token, 'npm_xxx')
+  assert.is(config.dbPassword, 's3cr3t')
+  assert.is(config.password, 'db-secret')
+})
+
+test('sync result equals async result for the same fake op', async () => {
+  const syncConfig = configorama.sync(yamlFile, {
+    variableSources: [createOnePasswordResolver({ refs })],
+  })
+  const asyncConfig = await configorama(yamlFile, {
+    variableSources: [createOnePasswordResolver({ refs })],
+  })
+  assert.equal(syncConfig, asyncConfig)
+})
+
+test('sync returnMetadata surfaces opReferences from the worker', () => {
+  const result = configorama.sync(yamlFile, {
+    returnMetadata: true,
+    variableSources: [createOnePasswordResolver({ refs })],
+  })
+  assert.is(result.config.token, 'npm_xxx')
+  assert.ok(Array.isArray(result.metadata.opReferences))
+  assert.is(result.metadata.opReferences.length, 3)
+  const serialized = JSON.stringify(result.metadata.opReferences)
+  assert.is(serialized.includes('npm_xxx'), false)
+  assert.is(serialized.includes('db-secret'), false)
+})
+
+test('sync mode rejects injected execFile options', () => {
+  const source = createOnePasswordResolver({ refs, execFile: () => {} })
+  try {
+    configorama.sync(yamlFile, { variableSources: [source] })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /not serializable for sync usage/)
+  }
+})
+
+test.run()

--- a/tests/packaging/packaging.test.js
+++ b/tests/packaging/packaging.test.js
@@ -1,0 +1,39 @@
+/* Tests root package exports and tarball contents for bundled plugins
+   Uses Node package self-reference for exports and npm pack --dry-run for files */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const rootDir = path.join(__dirname, '..', '..')
+
+test('configorama/plugins/cloudformation resolves through package exports', () => {
+  const factory = require('configorama/plugins/cloudformation')
+  assert.type(factory, 'function')
+})
+
+test('configorama/plugins/onepassword resolves through package exports', () => {
+  const factory = require('configorama/plugins/onepassword')
+  assert.type(factory, 'function')
+})
+
+test('npm pack includes plugin entry points and excludes dev files', () => {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json'], { cwd: rootDir, encoding: 'utf8' })
+  const [result] = JSON.parse(output)
+  const files = result.files.map((file) => file.path)
+
+  assert.ok(files.includes('plugins/cloudformation/index.js'), 'cloudformation index published')
+  assert.ok(files.includes('plugins/onepassword/index.js'), 'onepassword index published')
+  assert.ok(files.includes('plugins/onepassword/sync-factory.js'), 'sync factory published')
+
+  // npm-packlist force-includes lockfiles of nested package dirs, so
+  // plugins/*/package-lock.json cannot be negated away - harmless to ship.
+  const offenders = files.filter((file) => {
+    return /^plugins\/.*\.test\.js$/.test(file)
+      || /^plugins\/[^/]+\/example\//.test(file)
+      || /node_modules/.test(file)
+  })
+  assert.equal(offenders, [])
+})
+
+test.run()

--- a/tests/security/auditCustomResolvers.test.js
+++ b/tests/security/auditCustomResolvers.test.js
@@ -1,0 +1,69 @@
+/* eslint-disable no-template-curly-in-string */
+/* Tests audit findings for custom resolvers
+   Sensitive resolvers get a specific high finding; plain ones stay generic */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const configorama = require('../../src')
+
+const sensitiveSource = {
+  type: 'vaulty',
+  source: 'remote',
+  sensitive: true,
+  risk: 'remote_secret_read',
+  description: 'Resolves values from FakeVault',
+  match: /^vaulty:/,
+  resolver: () => Promise.resolve('secret'),
+}
+
+const plainSource = {
+  type: 'custom',
+  match: /^custom:/,
+  resolver: () => Promise.resolve('value'),
+}
+
+test('sensitive resolver yields a specific high-severity finding', async () => {
+  const report = await configorama.audit(
+    { value: '${vaulty:thing}' },
+    { variableSources: [sensitiveSource] }
+  )
+  const finding = report.findings.find((entry) => entry.id === 'customResolver:vaulty')
+  assert.ok(finding)
+  assert.is(finding.severity, 'high')
+  assert.is(finding.risk, 'remote_secret_read')
+  assert.is(finding.sensitive, true)
+  assert.is(finding.variableType, 'vaulty')
+  assert.match(finding.message, /reads secret values/)
+  assert.match(finding.message, /FakeVault/)
+})
+
+test('plain custom resolver keeps the generic custom_extension finding', async () => {
+  const report = await configorama.audit(
+    { value: '${custom:thing}' },
+    { variableSources: [plainSource] }
+  )
+  const finding = report.findings.find((entry) => entry.id === 'customResolver:custom')
+  assert.ok(finding)
+  assert.is(finding.risk, 'custom_extension')
+  assert.match(finding.message, /can execute user-provided code/)
+  assert.is(finding.sensitive, undefined)
+})
+
+test('one finding per resolver, no double-reporting', async () => {
+  const report = await configorama.audit(
+    { value: '${vaulty:thing}' },
+    { variableSources: [sensitiveSource] }
+  )
+  const findings = report.findings.filter((entry) => entry.id === 'customResolver:vaulty')
+  assert.is(findings.length, 1)
+})
+
+test('summary counts include the sensitive high finding', async () => {
+  const report = await configorama.audit(
+    { value: '${vaulty:thing}' },
+    { variableSources: [sensitiveSource] }
+  )
+  assert.ok(report.summary.high >= 1)
+  assert.is(report.summary.total, report.findings.length)
+})
+
+test.run()

--- a/tests/syncFactory/mock-plugin-factory.js
+++ b/tests/syncFactory/mock-plugin-factory.js
@@ -1,0 +1,24 @@
+/* Mock plugin factory for sync bridge tests
+   Returns a variable source with resolver + metadata like a real plugin */
+
+/**
+ * @param {object} options - JSON-round-tripped syncOptions
+ * @returns {object} Variable source
+ */
+module.exports = function createMockSource(options = {}) {
+  const collected = []
+  return {
+    type: 'mock',
+    match: /^mock:/,
+    resolver: async (varString, opts, currentObject, valueObject) => {
+      collected.push({
+        raw: valueObject.originalSource,
+        varString,
+        receivedOptions: options,
+      })
+      return `resolved-${varString.slice(5)}${options.suffix || ''}`
+    },
+    metadataKey: 'mockReferences',
+    collectMetadata: () => collected,
+  }
+}

--- a/tests/syncFactory/syncFactory.test.js
+++ b/tests/syncFactory/syncFactory.test.js
@@ -1,0 +1,79 @@
+/* Tests for the syncFactory plugin contract in configorama.sync()
+   Plugin factories rebuild real sources inside the sync-rpc worker */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const path = require('path')
+const configorama = require('../../src')
+
+const yamlFile = path.join(__dirname, 'syncFactory.yml')
+const factoryPath = path.join(__dirname, 'mock-plugin-factory.js')
+
+/**
+ * Build the plugin-style source as the async API would hand it over.
+ * match is a RegExp and resolver a function - neither survives the
+ * JSON trip to the worker; syncFactory/syncOptions must carry the day.
+ * @param {object} [syncOptions] - Options for the worker-side factory
+ * @returns {object} Variable source
+ */
+function pluginSource(syncOptions = {}) {
+  return {
+    type: 'mock',
+    match: /^mock:/,
+    resolver: async () => 'never-called-in-sync',
+    metadataKey: 'mockReferences',
+    collectMetadata: () => [],
+    syncFactory: factoryPath,
+    syncOptions,
+  }
+}
+
+test('sync resolves values through a syncFactory source', () => {
+  const config = configorama.sync(yamlFile, {
+    variableSources: [pluginSource()],
+  })
+  assert.is(config.value, 'resolved-hello')
+  assert.is(config.other, 'resolved-world')
+})
+
+test('syncOptions round-trip to the worker factory as JSON', () => {
+  const config = configorama.sync(yamlFile, {
+    variableSources: [pluginSource({ suffix: '-sfx' })],
+  })
+  assert.is(config.value, 'resolved-hello-sfx')
+})
+
+test('returnMetadata surfaces plugin metadata from the worker', () => {
+  const result = configorama.sync(yamlFile, {
+    returnMetadata: true,
+    variableSources: [pluginSource()],
+  })
+  assert.is(result.config.value, 'resolved-hello')
+  assert.ok(Array.isArray(result.metadata.mockReferences))
+  assert.is(result.metadata.mockReferences.length, 2)
+  const raws = result.metadata.mockReferences.map((entry) => entry.raw).sort()
+  assert.equal(raws, ['${mock:hello}', '${mock:world}'])
+})
+
+test('sources without syncFactory still require string descriptors', () => {
+  try {
+    configorama.sync(yamlFile, {
+      variableSources: [{ type: 'mock', match: /^mock:/, resolver: async () => 'x' }],
+    })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /must be string for .sync usage/)
+  }
+})
+
+test('missing syncFactory file throws a clear error', () => {
+  try {
+    configorama.sync(yamlFile, {
+      variableSources: [pluginSource() && { ...pluginSource(), syncFactory: path.join(__dirname, 'nope.js') }],
+    })
+    assert.unreachable('should have thrown')
+  } catch (err) {
+    assert.match(err.message, /Sync factory missing/)
+  }
+})
+
+test.run()

--- a/tests/syncFactory/syncFactory.yml
+++ b/tests/syncFactory/syncFactory.yml
@@ -1,0 +1,3 @@
+plain: no variables here
+value: ${mock:hello}
+other: ${mock:world}


### PR DESCRIPTION
## Summary

Adds an opt-in **1Password resolver plugin** at `plugins/onepassword/` that resolves config values through the `op` CLI, plus the core plumbing it needs (sync contract, audit support, bundled-plugin exports).

Secrets are fetched at resolution time and never persisted or logged by the plugin. No new npm dependencies — requires the `op` binary on `PATH`.

## What's included

**Plugin (`plugins/onepassword/`)**
- Alias syntax `${op:npm.NPM_TOKEN}` and direct function syntax `${op(op://vault/item/field)}`, item IDs/names (spaces OK), and private item links (Copy Private Link)
- INI/dotenv key paths into secure notes; `${op:alias}` returns raw field text (never parsed unless a key path is requested)
- Field inference with **ambiguity-is-an-error** semantics — never silently prefers `notesPlain` over `password`
- Per-instance promise caching; **cold-start latch** so N items trigger one auth prompt, not N
- Sanitized errors (no secrets/stderr in messages); private links redacted from metadata
- `skipResolution` placeholders; `sensitive: true` / `risk: 'remote_secret_read'`
- Works through async `configorama()` and `configorama.sync()`

**Core changes**
- `src/sync.js`: `syncFactory` contract — plugins carry a factory path + JSON `syncOptions` the worker rebuilds; worker now collects plugin metadata for `returnMetadata` sync callers
- `src/index.js` + `audit.js`: specific high-severity `remote_secret_read` audit finding for sensitive resolvers
- `package.json`: `require('configorama/plugins/{cloudformation,onepassword}')` now resolve from an installed package (the documented CF subpath was previously broken)

## Testing

- Full suite green: 27 slow + 690 lib + 1177 integration, typecheck clean
- Mocked unit tests throughout; sync e2e via a fake `op` shim (no mocked behavior in the worker); packaging verified with `npm pack --dry-run`
- Validated end-to-end against a real 1Password vault; env-gated real-CLI smoke test (`CONFIGORAMA_OP_E2E=1`) off by default

## Security

Reviewed. Hardened arg-injection surface (flag-like item/vault values rejected before spawning `op`). Documented security model: direct syntax reads whatever the `op` session can reach, so untrusted config should run under `safeMode: true` (blocks all custom resolvers) — see `plugins/onepassword/README.md`.
