### PR TITLE
chore(configx): publish prep — pin configorama ^1.1.0, metadata, LICENSE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "configorama",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "configorama",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "configorama",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Variable support for configuration files",
   "main": "src/index.js",
   "types": "index.d.ts",

--- a/packages/configx/LICENSE
+++ b/packages/configx/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) David Wells
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/configx/package.json
+++ b/packages/configx/package.json
@@ -15,7 +15,8 @@
   "files": [
     "cli.js",
     "src/resolveEnv.js",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "keywords": [
     "configorama",
@@ -24,9 +25,22 @@
     "dotenv",
     "secrets"
   ],
+  "author": "David Wells",
   "license": "MIT",
+  "homepage": "https://github.com/DavidWells/configorama/tree/master/packages/configx#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/DavidWells/configorama",
+    "directory": "packages/configx"
+  },
+  "bugs": {
+    "url": "https://github.com/DavidWells/configorama/issues"
+  },
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
-    "configorama": "^1.0.2",
+    "configorama": "^1.1.0",
     "minimist": "^1.2.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Prepares configx 0.1.0 for its first npm publish.

- Pin dependency `configorama@^1.1.0` (the version with .env parsing, the 1Password plugin subpath export, and the stdout-hygiene fixes configx needs — 1.0.2 would break on both headline features).
- Add `repository` (with `directory: packages/configx`), `homepage`, `bugs`, `author`, and `engines` (node >=18).
- Add MIT `LICENSE`.

Validated: installing the configx tarball pulls published configorama@1.1.0; `require('configorama/plugins/onepassword')` resolves and a `.env` run resolves end-to-end (exit 0). Tarball is 5 files (cli.js, src/resolveEnv.js, README, LICENSE, package.json).