### PR TITLE
feat(op-cache): all-syntax final-value caching for 1Password reads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ _misc
 # Added by nax
 .nax/
 /refactor
+/packages/configorama/_result.json

--- a/docs/plans/op-cache-all-onepassword-syntax.md
+++ b/docs/plans/op-cache-all-onepassword-syntax.md
@@ -1,0 +1,736 @@
+# Cache All Configorama 1Password Syntax Flavors
+
+Status: reviewed spec. Design review 2026-07-07 settled: cached payloads are plugin-side JSON envelopes ({ value, fieldName }) so audit metadata stays identical between miss and hit runs; cache keys are NUL-joined fixed-order parts (no JSON hashing); `getOrSet` mirrors `read` for `OP_CACHE_DISABLED`/win32.
+
+## Goal
+
+Extend the `packages/configorama/plugins/onepassword` integration so the optional
+`@davidwells/op-cache` provider can cache every supported `${op...}` variable
+flavor, not only direct `op://vault/item/field` secret references.
+
+The practical target is the agent workflow:
+
+```bash
+configx .env -- node script.js
+configx .env -- node script.js
+configx .env -- node script.js
+```
+
+When those fresh Node processes resolve the same 1Password-backed values within
+the configured TTL, the first process may prompt through the normal 1Password CLI
+flow, but subsequent processes should reuse the in-memory daemon cache regardless
+of whether the config used aliases, item names, private item links, explicit
+fields, inferred fields, or structured note key paths.
+
+## Current State
+
+`@davidwells/op-cache` currently caches scalar `op read` results for direct
+secret references:
+
+```yaml
+directBare: ${op://vault/item/field}
+directFunc: ${op(op://vault/item/field)}
+aliasToRef: ${op:npmToken} # when refs.npmToken = "op://vault/item/field"
+```
+
+One nuance the rest of this plan builds on: `secretRef` **with a key path**
+already flows through the daemon cache today. `fetchValue` caches the whole
+backing field via `opCache.read(reference.ref)` and key selection happens
+afterward in the resolver (`packages/configorama/plugins/onepassword/index.js:226-230`
+and `index.js:313-317`). So `${op(op://vault/item/notesPlain).KEY}` currently
+stores the entire `notesPlain` field in the daemon. This plan changes that
+path's cached granularity from whole-field to final-value — a behavior change
+to an already-shipped cache path, not a pure expansion. No migration is
+needed: the synthetic refs below produce different cache keys, so old
+whole-field entries simply expire unused.
+
+The plugin path for direct refs is:
+
+```text
+parse variable
+-> reference.kind === "secretRef"
+-> readSecretRefWithOptionalCache(ref)
+-> opCache.read(ref)
+-> client checks daemon, runs op read on miss, stores scalar value
+```
+
+All item-like syntaxes currently bypass `op-cache`:
+
+```yaml
+aliasRaw: ${op:npm}
+aliasKey: ${op:npm.NPM_TOKEN}
+itemField: ${op(database-prod).password}
+itemKey: ${op(note-item).database.password}
+privateLinkKey: ${op(https://start.1password.com/open/i?...).NPM_TOKEN}
+objectExplicit: # refs.database = { item, vault, section, field }
+```
+
+Those paths use:
+
+```text
+op item get <item|name> --vault <vault> --format json --reveal
+-> local field selection or inference
+-> optional structured INI/dotenv parsing
+-> return final value
+```
+
+The resolver has an in-process `itemCache`, so duplicate item reads within one
+Configorama process already share one `op item get`. That does not help the
+fresh-process `configx`/agent loop.
+
+## Supported Syntax Inventory
+
+The plan must preserve behavior for all existing forms:
+
+| Syntax | Normalized form | Current op path | Desired cache behavior |
+| --- | --- | --- | --- |
+| `${op://vault/item/field}` | `secretRef` | `op read` | Cache exact scalar ref, unchanged |
+| `${op(op://vault/item/field)}` | `secretRef` | `op read` | Cache exact scalar ref, unchanged |
+| `${op(op://vault/item/notesPlain).KEY}` | `secretRef` + keyPath | `op read` then parse | Cache final selected key value (change: today caches the whole field) |
+| `${op:alias}` where alias is `op://...` | `secretRef` | `op read` | Cache exact scalar ref, unchanged |
+| `${op:alias.KEY}` where alias is `op://...` | `secretRef` + keyPath | `op read` then parse | Cache final selected key value (change: today caches the whole field) |
+| `${op:alias}` where alias is item/name/link/object | `item`/`privateLink` | `op item get --reveal` | Cache final resolved value |
+| `${op:alias.KEY}` | `item`/`privateLink` + keyPath | `op item get --reveal` then select/parse | Cache final resolved value |
+| `${op(item-id).field}` | `item` + keyPath | `op item get --reveal` | Cache final resolved value |
+| `${op(item-name).field}` | `item` + keyPath | `op item get --reveal` | Cache final resolved value |
+| `${op(private-link).KEY}` | `privateLink` + keyPath | `op item get --reveal` | Cache final resolved value |
+| `refs.alias = { item, vault, section, field }` | `item` explicit field | `op item get --reveal` | Cache final resolved value |
+| `refs.alias = { url }` | `privateLink` | `op item get --reveal` | Cache final resolved value |
+
+Unsupported syntax remains unsupported:
+
+- `${op:op://vault/item/field}` still errors and points to function syntax.
+- Private links in colon syntax still error.
+- Public share links remain rejected.
+
+## Non-Goals
+
+- Do not silently enable caching just because `@davidwells/op-cache` is installed.
+- Do not persist secrets or item JSON to disk.
+- Do not require a new daemon protocol for whole-item JSON caching in this pass.
+- Do not make configx own secret cache state.
+- Do not cache failures, missing fields, auth errors, parse errors, or ambiguity.
+- Do not weaken `OP_CACHE_DISABLED=1`.
+- Do not cache when `OP_SERVICE_ACCOUNT_TOKEN` is set unless
+  `allowServiceAccountTokenCache: true` is explicitly configured.
+
+## Core Decision: Cache Final Resolver Values
+
+Cache final resolved values for non-direct syntaxes, not whole `op item get`
+JSON.
+
+For an item/private-link syntax, the plugin already knows how to:
+
+1. fetch the item JSON;
+2. select an explicit or inferred field;
+3. optionally treat the first key path segment as a field selector;
+4. parse structured INI/dotenv content only when a key path remains;
+5. return the exact string Configorama needs.
+
+The cache key should represent that final resolver operation. On cache hit, the
+plugin can return the final value without fetching item JSON at all.
+
+This avoids expanding the daemon's secret surface from "one resolved value" to
+"full item JSON with every revealed field". It also avoids tying `op-cache` to
+Configorama-specific field selection logic.
+
+### Why Not Cache Whole Item JSON?
+
+Whole item JSON caching would reduce repeated reads for multiple fields on the
+same item across separate processes, but it has worse tradeoffs for v1:
+
+- it stores more secret material than the caller requested;
+- it would require item JSON cache APIs, schemas, and tests in `@davidwells/op-cache`;
+- it would make `op-cache` aware of 1Password item shape instead of remaining a
+  scalar secret cache primitive;
+- it would make invalidation more complex when a single field changes;
+- it would make stats/debugging less obviously secret-minimal.
+
+Final-value caching matches the current daemon design and keeps the feature
+small enough to ship safely.
+
+### Accepted Tradeoff
+
+If one config resolves three different key paths from the same structured note:
+
+```yaml
+a: ${op:npm.NPM_TOKEN}
+b: ${op:npm.database.password}
+c: ${op:npm.GITHUB_TOKEN}
+```
+
+the first fresh process still uses the existing in-process `itemCache`, so it
+runs one `op item get`. It will then store three final values under three cache
+keys. Later fresh processes hit all three values without `op`.
+
+That is good enough for the motivating repeated-agent-command workflow.
+
+Two more tradeoffs to state plainly:
+
+- **Regression case for whole-field sharing.** Today, N key paths off one
+  cached `notesPlain` field cost zero op calls in a fresh process once the
+  field is cached. Under final-value caching, a key path not previously
+  resolved is a fresh `op read`/`op item get` even when a sibling key is
+  cached. Fine for the configx loop (same keys every run); it is a tradeoff,
+  not a free win.
+- **Dual-entry duplication in mixed configs.** `x: ${op(op://v/i/notesPlain)}`
+  stores the whole field under the direct-read key while
+  `y: ${op(op://v/i/notesPlain).KEY}` stores the extracted key under a
+  synthetic key. The daemon can hold both granularities of the same secret
+  simultaneously. Accepted: each entry is still exactly what some caller
+  asked for.
+
+### Cached Payload: Plugin-Side Envelope
+
+For inferred-field reads, the resolver backfills `entry.field` in
+`opReferences` audit metadata with the field it discovered during the fetch
+(`index.js:309-311`). A cache hit skips the fetch, so the discovered field
+name must ride along with the cached value or audit output would differ
+between miss runs and hit runs.
+
+Decision: the producer returns a JSON envelope **as a string**, and the
+envelope is a private convention of the plugin. `@davidwells/op-cache` gains
+the `getOrSet` API described below, but it does not understand this envelope:
+the protocol, daemon, and "producer returns a plain string" contract all hold,
+and the daemon stores opaque strings either way:
+
+```json
+{"value":"...","fieldName":"credential"}
+```
+
+Rules:
+
+- the plugin encodes on produce and decodes on every return (hit or miss),
+  records `fieldName` into metadata, and returns `value`;
+- envelope parse failure on a hit is treated as a cache miss: recompute via
+  the producer and overwrite the entry;
+- envelope shape changes ride under the resolver cache schema version that is
+  already a key dimension — a shape change produces new keys and old entries
+  expire unread, so the envelope needs no version field of its own;
+- direct `op://` reads through `opCache.read` keep storing raw values; the
+  daemon holds two entry formats (raw scalars and envelope JSON) and does not
+  care — this is cosmetic, visible only when debugging entries;
+- field labels ("credential", "password") are not secrets; caching them next
+  to the value is acceptable.
+
+This buys byte-identical `opReferences` audit metadata regardless of cache
+temperature — audit output that changes based on cache state would be a
+worse wart than the encode/decode round-trip.
+
+## Cache Key Model
+
+Direct `op://` scalar reads keep using `opCache.read(ref, ...)`, whose key is
+computed by the package from:
+
+```text
+version | scope | account | configDir | opPath | reference
+```
+
+For final-value resolver caching, Configorama should compute a deterministic
+synthetic cache reference and ask `op-cache` to cache the value under that ref.
+
+Synthetic ref shape (canonical — this is the single key spec for this plan):
+
+```text
+configorama-op://v1/<sha256hex>
+```
+
+Where the hash is computed over NUL-joined fixed-order parts, the same idiom
+`packages/op-cache/src/key.js` already uses — no JSON hashing, so there is no
+key-ordering/canonicalization pitfall:
+
+```text
+schemaVersion \0 kind \0 itemOrRef \0 vault \0 section \0 field \0 keyPath
+```
+
+- `schemaVersion`: resolver cache schema version (`v1`); bump it whenever
+  selection semantics or the envelope shape change — old entries then expire
+  unread
+- `kind`: `item | privateLink | secretRef` (normalized)
+- `itemOrRef`: normalized item ID/name, or the `op://` ref for secretRef
+- `vault` / `section` / `field`: normalized values or empty string
+- `keyPath`: requested key path or empty string
+
+There is deliberately no `selectionMode` dimension: it is fully derivable from
+`field`/`keyPath` presence, and `schemaVersion` covers future changes to the
+selection algorithm.
+
+`account`, `configDir`, and `opPath` are deliberately NOT part of the
+synthetic ref. They travel via `getOrSet` opts and `op-cache` applies them as
+cache key dimensions exactly as it does for `read`
+(`packages/op-cache/src/key.js:34-44`). One owner per dimension — putting them
+in both places invites silent partition drift when one site changes and the
+other does not.
+
+The daemon only sees the synthetic ref's hash-derived cache key, not the raw
+private link URL or full item JSON.
+
+Important: do not put raw private link URLs into synthetic refs. Normalize them
+to item/vault IDs first, as current metadata already does.
+
+## Required API Addition in `@davidwells/op-cache`
+
+Today `op-cache.read(ref, opts)` always fetches misses by running:
+
+```bash
+op read --no-newline <ref>
+```
+
+For final-value caching, Configorama needs "get or compute" semantics where the
+miss producer is local plugin logic, not `op read`.
+
+Add a programmatic API:
+
+```js
+const value = await opCache.getOrSet(cacheRef, async () => {
+  return computeResolvedValueWithCurrentPluginLogic()
+}, {
+  account,
+  configDir,
+  opPath,
+  ttlSeconds,
+  scope,
+  fallbackToOp: false,
+  stderr: process.stderr
+})
+```
+
+Semantics:
+
+- compute the same cache key dimensions as `read`, using `cacheRef` as the
+  reference dimension; `getOrSet` accepts any non-empty reference string — it
+  must NOT reuse `read`'s `op://` prefix guard
+  (`packages/op-cache/src/api.js:16`);
+- mirror `read`'s bypass behavior exactly (`api.js:20-22`):
+  `OP_CACHE_DISABLED=1` or win32 → run the producer directly, never touch the
+  daemon. The API owns this, as settled in v1; the plugin's
+  `shouldBypassOpCache` stays as belt-and-suspenders;
+- auto-start daemon on get, same as read;
+- on hit, first run `opts.validateCached(value)` when provided. If it returns
+  `false` or throws, treat the entry as unusable, recompute via the producer,
+  and overwrite the cache entry. This hook exists specifically so the
+  onepassword plugin can reject malformed JSON envelopes without needing a
+  public `set`/`delete` API. Emit a one-line stderr note on rejection, at
+  most once per process (same pattern as the clamp warning) — a validator
+  that persistently rejects means every process recomputes forever, and that
+  cache-defeat must be visible, not silent;
+- on hit that passes validation (or with no validator), return cached value;
+- on miss, call the producer in the client process;
+- if producer resolves, store the returned string with TTL and return it;
+  require a string and throw on anything else;
+- if producer rejects, do not store anything;
+- respect daemon TTL clamp; emit the clamp warning at most once per process —
+  a config resolving 20 cached values against a clamping daemon must not
+  print 20 identical stderr lines;
+- send `refHash: shortHash(cacheRef)` and `accountHash` on set, matching
+  `read`'s diagnostic metadata (`api.js:38-39`);
+- respect socket safety checks;
+- expose the same fail-closed vs fallback policy shape.
+
+The CLI does not need a public `get-or-set` command because producers are
+functions. This is API-only.
+
+Known limitation, same as v1 `read`: two fresh processes concurrently missing
+the same key both run the producer (both run `op item get`) and may both
+prompt. Accepted — the motivating workflow is sequential agent commands. Do
+not add ad hoc locking; if it ever matters, design daemon-side request
+coalescing deliberately.
+
+### Fallback Semantics for `getOrSet`
+
+For Configorama plugin integration:
+
+- default `fallbackToOp: false` means daemon failure fails closed before running
+  the producer;
+- `fallbackToOp: true` means daemon failure runs the producer directly and emits
+  the same style of stderr warning as `read`;
+- producer failure always surfaces as the producer's sanitized error.
+
+Naming note: in `getOrSet` the fallback runs the producer, not `op` itself.
+Document the option as "on daemon failure, do the work directly". Producers
+here always bottom out in `op`, and keeping one option name flowing from
+`cache.fallbackToOp` through both `read` and `getOrSet` is worth the slight
+imprecision.
+
+This matches the existing plugin policy: a broken configured cache is a hard
+failure unless the user opts into degradation.
+
+## Resolver Refactor
+
+Introduce a single resolver operation boundary:
+
+```js
+async function resolveReference(reference, keyPath, label) {
+  if (reference.kind === 'secretRef' && keyPath === undefined) {
+    return readSecretRefWithOptionalCache(reference.ref)
+  }
+
+  return resolvedValueWithOptionalCache(reference, keyPath, label, () => {
+    return resolveReferenceWithoutPersistentCache(reference, keyPath, label)
+  })
+}
+```
+
+`resolveReferenceWithoutPersistentCache` should contain the current behavior:
+
+- direct secret ref read;
+- item JSON fetch with in-process item cache;
+- explicit field selection;
+- key-path first-segment field selection;
+- inferred field selection;
+- structured parse and key lookup.
+
+`resolvedValueWithOptionalCache` should:
+
+- bypass when no `opCache`;
+- bypass when `OP_CACHE_DISABLED=1`;
+- bypass when `execFile` is injected;
+- bypass when `OP_SERVICE_ACCOUNT_TOKEN` is set and not explicitly allowed;
+- create a synthetic cache ref from normalized reference + keyPath + resolver
+  selection inputs;
+- call `opCache.getOrSet`.
+
+Direct `op://` with no key path can continue to call `opCache.read(ref)`. This
+keeps the fast path compatible with standalone `op-cache read`.
+
+Direct `op://` with a key path should use final-value caching:
+
+```yaml
+value: ${op(op://vault/item/notesPlain).NPM_TOKEN}
+```
+
+The cache should store only `NPM_TOKEN`, not the whole notes field, because the
+caller asked for one final value.
+
+## Selection Metadata and Cache Keys
+
+The cache key must be stable before a miss computes the item. That means it can
+include requested inputs but not discovered outputs like "the inferred field was
+credential" unless the plugin performs an uncached lookup first.
+
+Key dimensions are exactly the canonical synthetic ref spec above (schema
+version, kind, itemOrRef, vault, section, field, keyPath) plus the
+`account`/`configDir`/`opPath` dimensions `op-cache` applies from opts. There
+is one key spec in this document; do not derive a second one.
+
+For inferred-field reads, the key says "infer the field for this item with this
+keyPath", not "credential" — but the DISCOVERED field name is preserved in the
+cached envelope (see Cached Payload above), so audit metadata is identical on
+hits and misses. If the item's fields change while the cache entry is live, the
+cached value may remain until TTL expiry. That is already true for direct
+`op://` field changes and is acceptable within a short TTL.
+
+If this becomes surprising, later versions can add a `cache.schemaVersion` or
+`cache.inferredFieldSalt` option, but v1 should keep TTL as the invalidation
+mechanism.
+
+## Private Link Handling
+
+Private links must never be stored raw in metadata, logs, or synthetic refs.
+
+Current normalization extracts:
+
+```text
+i = item ID
+v = vault ID
+```
+
+The cache key should use only:
+
+```json
+{
+  "kind": "privateLink",
+  "item": "<item id>",
+  "vault": "<vault id or undefined>"
+}
+```
+
+Private links without `v` remain supported with the existing warning. Their
+cache keys omit vault. This preserves current behavior but means duplicate item
+names/IDs across contexts are only as safe as the original lookup. Account and
+configDir remain part of the key.
+
+## Option Shape
+
+Keep the existing option:
+
+```js
+cache: {
+  provider: 'op-cache',
+  ttlSeconds: 300,
+  scope: 'user',
+  fallbackToOp: false,
+  allowServiceAccountTokenCache: false
+}
+```
+
+Do not add a `mode` or `itemSyntax` switch. The user intent is clear and the
+feature is still pre-publish: when `cache.provider === 'op-cache'`, all
+supported onepassword plugin syntaxes are cacheable under the final-value model.
+
+## Backward Compatibility
+
+No behavior changes when:
+
+- `cache` is not configured;
+- `cache.provider` is not `'op-cache'`;
+- `OP_CACHE_DISABLED=1`;
+- tests inject `execFile`;
+- `OP_SERVICE_ACCOUNT_TOKEN` is set without
+  `allowServiceAccountTokenCache: true`.
+
+With caching configured, more values will be cached than before. This is a
+feature expansion, but it affects security posture. Documentation must clearly
+state:
+
+- enabling op-cache caches final resolved values for all onepassword plugin
+  syntaxes;
+- values live in daemon memory until TTL expiry, clear, or stop;
+- secrets are still never written to disk by op-cache;
+- short TTLs are recommended for interactive agents.
+
+## Testing Plan
+
+### `@davidwells/op-cache` API Tests
+
+Add tests for `getOrSet`:
+
+- cache miss calls producer once, stores value, returns value;
+- cache hit does not call producer;
+- `validateCached` can reject a hit, causing producer recompute and overwrite;
+- `validateCached` rejection emits a stderr note at most once per process;
+- producer rejection is not cached;
+- daemon failure fails closed when fallback is false;
+- daemon failure runs producer when fallback is true and emits bypass warning;
+- TTL expiration causes producer to run again;
+- scope separation keeps `scope:a` and `scope:b` isolated;
+- key partitioning: changed `account`, `configDir`, or `opPath` opts produce a
+  miss for the same `cacheRef`;
+- non-string producer return value throws and is not stored;
+- `OP_CACHE_DISABLED=1` bypasses daemon and runs producer each call (the API
+  owns disabled handling, settled in v1 — `api.js:20-22`);
+- win32 (platform-stubbed) runs producer directly, never touches a socket;
+- TTL clamp warning emitted at most once per process across many `getOrSet`
+  calls;
+- set message carries `refHash`/`accountHash` diagnostics, matching `read`.
+
+### Onepassword Plugin Unit/Integration Tests
+
+Update `packages/configorama/plugins/onepassword/op-cache.test.js`.
+
+Replace the current assertion:
+
+```text
+item reads do not use op-cache daemon
+```
+
+with tests proving item syntaxes do use op-cache when configured:
+
+- alias to item raw field caches across separate processes;
+- alias to structured note key path caches across separate processes;
+- direct item ID function syntax caches final selected field;
+- item name function syntax caches final selected field;
+- private link syntax caches final selected value and does not expose raw URL in
+  metadata or cache ref;
+- object refs with `{ item, vault, field }` cache final selected value;
+- explicit section+field refs cache separately from same field label in another
+  section;
+- direct `op://...` with key path caches final key value;
+- `OP_CACHE_DISABLED=1` bypasses all syntax caches;
+- service account token bypass applies to all syntax caches unless allowed;
+- missing op-cache package still gives install hint only when cache configured;
+- envelope round-trip: producer encodes `{value, fieldName}`, hit decodes and
+  returns the same value with the same metadata;
+- envelope parse failure on a hit is treated as a miss: producer reruns and
+  overwrites the entry;
+- `opReferences` metadata is identical between a miss run and a hit run,
+  including `field` backfill for inferred-field reads;
+- the sync-worker resolution path (sync-factory receives the `cache` option
+  via `buildSyncOptions`, `index.js:344-357`) caches and hits the same way as
+  the async path.
+
+Use fake `op` binaries and temp sockets. Never call real 1Password from tests.
+
+### Regression Tests for Prompt Reduction
+
+Create a cross-process test that runs two separate Node processes resolving:
+
+```yaml
+a: ${op:npm.NPM_TOKEN}
+b: ${op(database-prod).password}
+c: ${op(private-link).credential}
+d: ${op(op://vault/item/field)}
+```
+
+Expected:
+
+- first process calls fake `op` once per distinct backing operation;
+- second process returns all values with zero fake `op` calls;
+- daemon stats show hits on the second process;
+- stdout remains only resolved config output.
+
+### Real Manual QA
+
+Use real 1Password only manually:
+
+```bash
+op-cache stop
+configx .env -- node infra/_scripts/hubspot-ops.js channels validate davidwells/projects
+configx .env -- node infra/_scripts/hubspot-ops.js channels validate davidwells/projects
+op-cache stats --json
+op-cache stop
+```
+
+Expected:
+
+- first command may prompt;
+- second command should not prompt for cached values within TTL;
+- `stats --json` shows entries and hits;
+- `OP_CACHE_DISABLED=1` restores old prompt behavior.
+
+## Implementation Phases
+
+### Phase 1: Add `getOrSet` to `@davidwells/op-cache`
+
+Files:
+
+- `packages/op-cache/src/api.js`
+- `packages/op-cache/src/client.js`
+- `packages/op-cache/test/unit.test.js`
+- `packages/op-cache/test/integration.test.js`
+
+Tasks:
+
+1. Add public `getOrSet(reference, producer, opts)`. Accept any non-empty
+   reference string (no `op://` guard).
+2. Reuse existing config resolution, scope resolution, cache key hashing, daemon
+   get/set messages, TTL clamp behavior, socket checks, and fallback handling.
+3. Mirror `read`'s bypass ladder: `OP_CACHE_DISABLED=1` or win32 run the
+   producer directly with no daemon contact.
+4. Require producer values to be strings; throw on non-strings, store nothing.
+5. Emit the TTL clamp warning at most once per process; send
+   `refHash`/`accountHash` on set for parity with `read`.
+6. Support optional `validateCached(value)` so integrations can reject a hit
+   and force producer recompute/overwrite; warn on stderr at most once per
+   process when rejection occurs.
+7. Export it from `src/api.js`.
+8. Add tests.
+
+### Phase 2: Refactor Resolver Around Final Value Computation
+
+Files:
+
+- `packages/configorama/plugins/onepassword/index.js`
+
+Tasks:
+
+1. Extract current item/direct resolution into a no-persistent-cache helper.
+2. Preserve the existing in-process `secretRefCache` and `itemCache`.
+3. Add synthetic cache ref builder implementing the canonical NUL-joined key
+   spec (schemaVersion, kind, itemOrRef, vault, section, field, keyPath).
+4. Add envelope encode/decode helpers: producer returns
+   `JSON.stringify({ value, fieldName })`; both hit and miss paths decode,
+   backfill `entry.field` metadata, and return `value`; pass a
+   `validateCached` hook to `opCache.getOrSet` so parse failure on hit is a
+   miss and overwrites the stale/malformed entry.
+5. Route all cacheable syntaxes through either:
+   - `opCache.read(ref)` for direct `op://` with no key path;
+   - `opCache.getOrSet(syntheticRef, producer)` for everything else.
+6. Preserve metadata behavior (now fully achievable via the envelope) and
+   private-link redaction.
+7. Preserve cold-start auth hint behavior on cache misses. Cache hits should not
+   print an auth hint because no `op` call occurs. The cold-start latch stays
+   inside the producer so cache hits never serialize behind it.
+
+### Phase 3: Update Tests
+
+Files:
+
+- `packages/configorama/plugins/onepassword/op-cache.test.js`
+- `packages/configorama/plugins/onepassword/index.test.js`
+
+Tasks:
+
+1. Replace item-bypass test with item-cache tests.
+2. Add cross-process tests for all major syntax families.
+3. Add private-link redaction assertion for synthetic cache refs if observable
+   through test hooks; otherwise assert metadata remains redacted and fake op
+   call count proves cache hit.
+4. Add service-token and disabled-cache coverage for item syntaxes.
+
+### Phase 4: Documentation
+
+Files:
+
+- `packages/configorama/plugins/onepassword/README.md`
+- `packages/op-cache/README.md`
+- `packages/configx/README.md`
+
+Tasks:
+
+1. Replace "Only direct secret references are cached in v1" with the new all
+   syntax behavior.
+2. Explain final-value caching and why item JSON is not cached.
+3. Document TTL, scope, daemon memory-only storage, and bypass controls.
+4. Add examples for aliases, private links, direct item syntax, and structured
+   note key paths.
+
+### Phase 5: Verification
+
+Required commands after code changes:
+
+```bash
+pnpm --filter @davidwells/op-cache test
+node packages/configorama/plugins/onepassword/op-cache.test.js
+node packages/configorama/plugins/onepassword/index.test.js
+npm run typecheck
+pnpm -r test
+```
+
+Package smoke after implementation:
+
+```bash
+pnpm --filter @davidwells/op-cache pack --pack-destination /tmp
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+npm init -y >/dev/null
+npm install /tmp/davidwells-op-cache-0.1.0.tgz
+./node_modules/.bin/op-cache --help
+```
+
+## Resolved Decisions
+
+1. `cache: { provider: 'op-cache' }` immediately means all syntaxes — no
+   `mode` switch. The feature is still pre-publish and user intent is clear.
+2. Direct `op://notesPlain.KEY` caches the final key, not the whole
+   `notesPlain` field — least secret surface per entry. Caveats accepted and
+   documented above: this changes an already-shipped cache path from
+   whole-field to final-value, mixed configs can hold both granularities of
+   the same secret simultaneously, and previously-unseen keys off a cached
+   field cost a fresh op call.
+3. `getOrSet` is public API, documented in the README as an "advanced
+   integration API", not a CLI feature.
+4. No user-configurable key namespace — scope already provides the
+   operational namespace.
+5. Cached payloads for `getOrSet` entries are plugin-side JSON envelopes
+   (`{ value, fieldName }`) so audit metadata is identical on hits and
+   misses. op-cache itself remains string-in/string-out.
+
+## Acceptance Criteria
+
+- With cache disabled or absent, current onepassword plugin behavior is
+  unchanged.
+- With cache configured, every supported `${op...}` syntax can avoid a second
+  `op` invocation across fresh Node processes inside TTL.
+- Cache stores final resolved values only (as plugin-side
+  `{ value, fieldName }` envelopes for `getOrSet` entries), never whole item
+  JSON.
+- `opReferences` audit metadata is identical between miss runs and hit runs.
+- Private links remain redacted from metadata and are not stored raw in
+  synthetic cache references.
+- Failed reads, missing fields, ambiguous field selection, auth errors, and
+  parse errors are not cached.
+- `OP_CACHE_DISABLED=1` bypasses all cache paths.
+- `OP_SERVICE_ACCOUNT_TOKEN` bypasses all cache paths unless explicitly allowed.
+- All stdout hygiene rules remain intact.
+- Required package/plugin/root tests and typecheck pass.

--- a/docs/plans/op-cache-js-package.md
+++ b/docs/plans/op-cache-js-package.md
@@ -1,0 +1,779 @@
+# @davidwells/op-cache JavaScript Package Plan
+
+Status: spec. Design decisions settled in interview review on 2026-07-05. Ready to implement once Phase 0 baseline is confirmed.
+
+## Goal
+
+Port `_misc/op-cache` into a first-class npm workspace package named `@davidwells/op-cache`.
+
+The package should preserve the Rust prototype's user-facing behavior while fitting the Configorama/configx ecosystem:
+
+- repeated `op://` reads inside agent workflows should avoid repeated 1Password biometric/thumbprint prompts;
+- secrets should be cached in memory only, never written to disk;
+- cache lifetime should be configurable per daemon and per request;
+- cache entries should be scopeable so agents, shells, CI jobs, or specific process families can avoid sharing secrets unintentionally;
+- `packages/configorama/plugins/onepassword` should be able to opt into the cache without making `configx` responsible for secret storage.
+
+The motivating case is an agent repeatedly running:
+
+```bash
+configx .env -- node infra/_scripts/hubspot-ops.js channels validate davidwells/projects
+```
+
+Each `configx` invocation is a fresh Node process, so the existing in-memory cache inside the 1Password resolver disappears between commands. A small per-user daemon solves that by keeping short-lived values in memory across process boundaries.
+
+## Decisions
+
+Settled in design review; each is expanded in its section below.
+
+| Decision | Outcome |
+| --- | --- |
+| `run` command | Dropped entirely. configx is the runner; op-cache is a pure cache primitive. |
+| Plugin wiring | Lazy optional `require('@davidwells/op-cache')`; clear install-hint error if missing. |
+| CLI daemon failure | Retry once (respawn), then fall through to direct `op read` with stderr warning. |
+| Plugin daemon failure | Fail closed by default; `cache.fallbackToOp: true` opts into degradation. |
+| Config file | Optional JSON at `~/.config/op-cache/config.json`. Zero runtime dependencies. |
+| Config precedence | CLI flags > `OP_CACHE_*` env > JSON file > defaults. |
+| Machine output | `--json` flag on status/stats/doctor; human text is the default. |
+| TTL clamp | Clamp to `max_ttl_seconds` with a one-line stderr warning. |
+| Session scope | `--scope session` with no session env is an error. `OP_CACHE_SESSION` beats `OP_CACHE_SCOPE`. |
+| Windows | Passthrough: `read` runs `op` directly, no cache; status/doctor report unavailable. |
+| Node floor | `>=22`. |
+| Stats | Global hit/miss counters only; per-scope stats report live entry counts. |
+| Daemon logging | No log file. Foreground mode logs via smart-log debug; background daemon is silent. |
+| Idle exit | Daemon exits after idle window only when the cache is empty. |
+| Spawn policy | Only `read` auto-starts the daemon. stats/clear/status report not-running. |
+| API shape | Module-level functions; config resolved once per process, per-call opts override. |
+| Publishing | lerna independent versioning, public on npm from 0.1.0. |
+| Rust prototype | Stays in `_misc/op-cache` as reference. Not maintained, not deleted. |
+
+## Non-Goals
+
+- Do not ship a command runner (`op-cache run`); `configx` is the runner in this ecosystem.
+- Do not bake a long-lived cache into `configx`.
+- Do not persist secret values to disk.
+- Do not silently enable caching in the 1Password resolver just because a cache binary exists.
+- Do not cache `op item get --reveal` JSON in the initial integration unless explicitly designed later.
+- Do not implement Windows caching in v1; op-cache degrades to passthrough there.
+- Do not require Bun for normal package use.
+
+## Source Prototype
+
+The Rust prototype lives at:
+
+```text
+_misc/op-cache
+```
+
+It remains in the repo as a design reference. It is not maintained alongside the JS package and its binary should be removed from PATH once the JS package is in use.
+
+Behavior to preserve:
+
+- `op-cache read op://vault/item/field`
+- `op-cache status`
+- `op-cache stats`
+- `op-cache clear`
+- `op-cache stop`
+- hidden daemon commands for background and foreground daemon operation
+- daemon auto-start on first `read`
+- in-memory TTL cache
+- max-entry cap
+- per-user Unix socket
+- socket permissions locked down to `0600`
+- cache key includes effective 1Password account
+- explicit account flag wins over ambient `OP_ACCOUNT`
+- cache misses are resolved by the client process, not the daemon
+
+That last point is load-bearing: the client should run `op read` so 1Password app integration and terminal attribution behave like the user expects. The daemon should be only a cache server.
+
+Intentionally not ported:
+
+- `op-cache run -- <command>` and its bounded concurrent resolution. Env injection is configx's job.
+
+## Package Placement
+
+```text
+packages/op-cache/
+  package.json
+  README.md
+  LICENSE
+  src/
+    cli.js
+    config.js
+    client.js
+    daemon.js
+    protocol.js
+    cache.js
+    op.js
+    errors.js
+    scope.js
+  test/
+    *.test.js
+```
+
+Package metadata:
+
+```json
+{
+  "name": "@davidwells/op-cache",
+  "bin": {
+    "op-cache": "./src/cli.js"
+  },
+  "type": "commonjs",
+  "engines": {
+    "node": ">=22"
+  }
+}
+```
+
+Zero runtime dependencies. Config is JSON (`JSON.parse`), hashing is `node:crypto`, IPC is `node:net`, and arg parsing is hand-rolled at this size. Use Node rather than Bun for the published package; Bun can still run it if compatible, but it must not be a runtime dependency.
+
+## Architecture
+
+### Process Model
+
+Use two process roles:
+
+1. Client CLI/API process
+2. Background daemon process
+
+For `read`:
+
+```text
+op-cache read REF
+  -> resolve config (flags > env > json file > defaults)
+  -> compute effective account and cache scope
+  -> hash cache key locally from the key dimensions
+  -> ensure daemon is running (read is the only command that spawns it)
+  -> send get with key and scope to daemon
+  -> on hit: print value to stdout
+  -> on miss: client runs `op read --no-newline REF`
+  -> client stores value in daemon with TTL and scope metadata
+  -> print value to stdout
+```
+
+The client computes the cache key hash; it has all the key dimensions. The daemon only ever sees opaque hashes plus the metadata it needs for scoped operations.
+
+Note: the Rust prototype runs plain `op read` and trims trailing whitespace. The JS package uses `op read --no-newline` instead, which preserves multiline secrets that legitimately end in newlines.
+
+### Daemon Failure Ladder
+
+The cache is an optimization, never an outage. When the daemon misbehaves (socket exists but connect fails, crash mid-request, spawn timeout), `op-cache read`:
+
+1. retries once, respawning the daemon if needed;
+2. if still broken, runs `op read` directly and prints the value;
+3. warns on stderr that the cache was bypassed and why.
+
+The exit code stays 0 when the fallback read succeeds. The programmatic API exposes this as `fallbackToOp`; the CLI always enables it, the onepassword plugin defaults it off (fail closed, see Resolver Integration).
+
+Known limitation: two processes missing the same key concurrently will both run `op read` and both trigger a biometric prompt. The motivating workflow is sequential agent commands, so v1 accepts this. Do not add ad hoc locking for it; if it becomes a real problem, design daemon-side request coalescing deliberately.
+
+### IPC
+
+Use a Unix domain socket on macOS/Linux.
+
+Default socket path:
+
+```text
+${TMPDIR:-/tmp}/op-cache-${uid}.sock
+```
+
+The Rust prototype uses `/tmp/op-cache.sock`; the JS package includes the UID by default to avoid accidental cross-user collisions on shared machines. Still set socket permissions to `0600` and verify owner/permissions before connecting.
+
+Wire protocol should be simple and inspectable:
+
+- newline-delimited JSON messages (the Rust prototype uses length-prefixed MessagePack; NDJSON is an intentional change for inspectability);
+- one request per connection is acceptable for v1;
+- request and response payloads must never log secret values;
+- cap incoming line length.
+
+Because cache keys are opaque hashes that already include the scope, the daemon cannot derive scope, TTL, or owner PID from a key. Those must travel in the messages and be stored as entry metadata, or scoped clear/stats and PID liveness checks are impossible.
+
+Requests:
+
+```text
+get       {"type":"get","key":"sha256:...","scope":"user"}
+          scope is required so the daemon can count entries per scope;
+          hits read scope from entry metadata.
+set       {"type":"set","key":"sha256:...","value":"...","scope":"user",
+           "ttlSeconds":300,"ownerPid":12345}
+          ttlSeconds sets expiresAt; scope is stored as entry metadata;
+          ownerPid is present only for pid/ppid scopes.
+ping      {"type":"ping"}
+clear     {"type":"clear"} or {"type":"clear","scope":"session:abc"}
+stats     {"type":"stats"} or {"type":"stats","scope":"session:abc"}
+shutdown  {"type":"shutdown"}
+```
+
+Responses:
+
+```text
+hit       {"type":"hit","value":"..."}
+miss      {"type":"miss"}
+stored    {"type":"stored","ttlSeconds":300,"clamped":false}
+pong      {"type":"pong","version":"...","ttlSeconds":300,"maxTtlSeconds":86400,
+           "maxEntries":1000,"idleExitSeconds":1800}
+cleared   {"type":"cleared","removed":12}
+stats     {"type":"stats","entries":12,"hits":40,"misses":9,"hitRate":0.82}
+          scoped: {"type":"stats","scope":"session:abc","entries":3}
+error     {"type":"error","message":"..."}
+```
+
+Scope strings are not secrets; storing them raw in the daemon is fine.
+
+Hit/miss counters are daemon-global only. Scope strings are caller-controlled and unbounded, so per-scope counters would grow without bound on a long-lived daemon; per-scope stats report live entry counts instead, which answers "is my scope populated" without unbounded state.
+
+The daemon necessarily sends secret values back to clients on cache hits, so socket ownership and permissions matter.
+
+### Daemon Lifecycle
+
+Spawn policy: only `read` auto-starts the daemon. `stats`, `clear`, and `status` against a stopped daemon report "daemon not running" without spawning one; `clear` exits 0 in that case because nothing-to-clear is not an error. This is an intentional behavior change from the Rust prototype, which spawned the daemon for every cache operation.
+
+The daemon resolves config (env + JSON file) at startup; clients resolve config on every invocation. To keep drift visible:
+
+- `pong` (and therefore `status`) reports the daemon's package version and effective TTL/max-entries/idle-exit config;
+- the client warns on stderr when the daemon version differs from its own, and `doctor` reports the mismatch;
+- `op-cache stop` followed by the next `read` is the documented reload path for v1;
+- the daemon exits on its own after `idle_exit_seconds` (default 30 minutes) of no connections, but only when the cache is empty. Live entries keep the daemon alive until they expire, so a valid cache entry is never dropped by idle exit; daemon lifetime is roughly TTL plus the idle window.
+
+Logging: the background daemon writes no log file. Anything worth logging in the background is worth surfacing in `status`/`stats`/`doctor` instead, and a secrets daemon should leave nothing sensitive-adjacent on disk. Debugging happens by running `op-cache daemon-foreground` with `DEBUG=op-cache:*` smart-log output. This intentionally drops the Rust prototype's sock-adjacent `.log` file.
+
+### Cache
+
+Use an in-memory LRU TTL cache implemented locally on `Map` — no dependency.
+
+Entry shape:
+
+```js
+{
+  value,
+  expiresAt,
+  createdAt,
+  lastAccessedAt,
+  scope,
+  ownerPid,
+  refHash,
+  accountHash
+}
+```
+
+The daemon must never store raw refs in stats output. It may store raw refs internally only if needed, but the preferred cache key path avoids that.
+
+Eviction rules:
+
+- expired entries are ignored and deleted on read;
+- a periodic sweep (every 60 seconds is fine) deletes expired entries that are never re-read, so secrets do not sit in daemon memory past their TTL;
+- `max_entries` evicts least-recently-used entries;
+- `ttlSeconds` on `set` is clamped to the daemon-side `max_ttl_seconds`; the `stored` response carries `clamped: true` and the client prints a one-line stderr warning so expiry behavior is never mysterious;
+- `clear` removes all entries by default;
+- scoped clear removes only entries whose scope metadata matches.
+
+## Platform Support
+
+macOS and Linux are fully supported via Unix domain sockets.
+
+On `win32`, op-cache degrades to passthrough: `read` executes `op read` directly with no daemon and no cache, and `status`/`doctor` report that caching is unavailable on this platform. This keeps shared configx configs with cache options portable across a team with Windows members — they just get the prompts. Named pipe support can come later if users ask.
+
+## Configuration
+
+Zero-dependency config. Precedence:
+
+1. CLI flags
+2. Environment variables
+3. Optional JSON config file
+4. Defaults
+
+Config file (optional):
+
+```text
+~/.config/op-cache/config.json
+```
+
+```json
+{
+  "socket_path": "/tmp/op-cache-501.sock",
+  "ttl_seconds": 300,
+  "max_ttl_seconds": 86400,
+  "max_entries": 1000,
+  "op_path": "op",
+  "op_timeout_seconds": 30,
+  "default_scope": "user",
+  "idle_exit_seconds": 1800
+}
+```
+
+Key names keep the Rust prototype's snake_case so the two documents read the same; the file format changes from YAML to JSON so `JSON.parse` covers it and the package keeps zero dependencies. If the file is absent, defaults apply.
+
+Default changes from Rust:
+
+- `ttl_seconds`: `300` seconds by default, not `86400`. 24 hours is useful for local speed but surprising for a package integrated into secret resolution; five minutes solves repeated agent commands without secrets lingering all day. Users can raise it explicitly.
+- `socket_path`: includes the uid by default (see IPC).
+
+Environment variables:
+
+```text
+OP_CACHE_SOCKET_PATH
+OP_CACHE_TTL_SECONDS
+OP_CACHE_MAX_TTL_SECONDS
+OP_CACHE_MAX_ENTRIES
+OP_CACHE_OP_PATH
+OP_CACHE_OP_TIMEOUT_SECONDS
+OP_CACHE_IDLE_EXIT_SECONDS
+OP_CACHE_SCOPE
+OP_CACHE_SESSION
+OP_CACHE_DISABLED
+```
+
+`OP_CACHE_DISABLED=1` means bypass the daemon entirely: `op-cache read` executes `op read` directly, and the onepassword plugin ignores its `cache` option. It never touches a running daemon's contents. This is the escape hatch when the cache misbehaves, so it must not itself depend on the daemon working.
+
+The programmatic API resolves config once per process on first use and caches it for the process lifetime; per-call options override resolved config. Fresh processes (the normal configx case) always see current env and file state.
+
+## TTL Design
+
+Support TTL at three levels:
+
+1. Daemon default TTL from config.
+2. CLI/request TTL via `--ttl <duration>`.
+3. Resolver integration TTL via plugin options.
+
+Duration input should accept:
+
+```text
+30s
+5m
+1h
+300
+```
+
+Bare numbers mean seconds.
+
+```bash
+op-cache read op://vault/item/field --ttl 5m
+```
+
+The request TTL is stored alongside the entry as `expiresAt = now + ttl`, clamped to `max_ttl_seconds` (clamp warns on stderr, see Cache). A later request with a longer TTL should not silently extend an existing cached secret unless we deliberately add `refreshTtlOnHit`. Default is no extension on hit.
+
+## Scope Design
+
+Scoping is explicit and string-based, not PID-only.
+
+Reasoning:
+
+- a raw PID dies too quickly for agent workflows because each shell command creates child processes;
+- PID reuse can cause confusing collisions if entries outlive the process;
+- agent "thread" identity is usually not the process ID;
+- a caller-provided namespace maps better to "same agent thread", "same repo", "same terminal", or "same CI job".
+
+Scopes:
+
+```text
+user         shared by all same-user callers using same account/config/op path (default)
+session      derived from OP_CACHE_SESSION, then OP_CACHE_SCOPE
+pid          current process id only
+ppid         parent process id
+custom       explicit string
+```
+
+There is deliberately no `global` alias for `user`: two names for the same partition invites "which one did I clear" confusion.
+
+Session scope rules:
+
+- `OP_CACHE_SESSION` wins over `OP_CACHE_SCOPE` when both are set — the dedicated variable beats the general one;
+- bare `--scope session` with neither env var set is an error telling the user to set `OP_CACHE_SESSION`. It never silently falls back to a shared scope, because "I thought this was isolated" is a secret-sharing surprise.
+
+CLI:
+
+```bash
+op-cache read op://vault/item/field --scope user
+op-cache read op://vault/item/field --scope session:claude-thread-abc
+op-cache read op://vault/item/field --scope pid
+op-cache clear --scope session:claude-thread-abc
+op-cache stats --scope session:claude-thread-abc
+```
+
+Environment:
+
+```bash
+export OP_CACHE_SCOPE="session:claude-thread-abc"
+```
+
+Cache key dimensions:
+
+```text
+version
+scope
+account
+configDir
+opPath
+reference
+```
+
+Hash the joined dimensions with SHA-256. Including `configDir` avoids collisions between separate 1Password CLI config directories. Including `opPath` avoids odd cases where users point at different `op` binaries; the resolved realpath string is the identity, no need to hash the binary itself.
+
+PID scope:
+
+- include `process.pid` in the scope string;
+- set TTL to the smaller of requested TTL and a conservative PID default unless overridden;
+- optionally check liveness for owner PID before returning a hit. The daemon cannot recover the PID from a hashed key, so it uses the `ownerPid` entry metadata sent with `set`.
+
+Session/custom scope:
+
+- caller owns the namespace;
+- recommended for agents because a controlling process can set one stable value for a thread.
+
+## CLI Surface
+
+```bash
+op-cache read <ref> [--account <account>] [--ttl <duration>] [--scope <scope>]
+op-cache status [--json]
+op-cache stats [--scope <scope>] [--json]
+op-cache clear [--scope <scope>]
+op-cache stop
+op-cache config-path
+op-cache doctor [--json]
+```
+
+Hidden/internal:
+
+```bash
+op-cache daemon
+op-cache daemon-foreground
+```
+
+`--json` emits one stable JSON object to stdout for status/stats/doctor; human-readable text is the default. Agents are the primary consumer here, and they pass the flag.
+
+`doctor` should report:
+
+- Node version;
+- `op` path and version if available;
+- socket path;
+- daemon status;
+- daemon version vs client version, flagging mismatch;
+- config path and whether the file exists;
+- whether socket permissions are safe;
+- whether `OP_SERVICE_ACCOUNT_TOKEN` is set, without printing its value;
+- platform passthrough status on win32.
+
+All diagnostics go to stderr unless the command's purpose is machine-readable stdout. Secret values only go to stdout for `read`.
+
+## Programmatic API
+
+Module-level functions; config resolved once per process, per-call options override:
+
+```js
+const { read, ensureDaemon, clear, stats, status } = require('@davidwells/op-cache')
+
+const value = await read('op://vault/item/field', {
+  account,
+  configDir,
+  opPath,
+  ttlSeconds: 300,
+  scope: 'user',
+  fallbackToOp: false
+})
+```
+
+`fallbackToOp` controls the daemon failure ladder: `true` degrades to direct `op read` after one retry (what the CLI does), `false` throws after the retry (what the plugin defaults to). The API is usable without shelling out to the `op-cache` CLI.
+
+## 1Password Resolver Integration
+
+The plugin lazy-requires the package only when the cache option is present:
+
+- `createOnePasswordResolver({ cache: { provider: 'op-cache', ... } })` triggers `require('@davidwells/op-cache')` at resolver setup;
+- if the package is not installed, fail immediately with a clear message including the install command;
+- no `cache` option means the plugin never touches op-cache and has no dependency on it.
+
+Config is explicit:
+
+```js
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+module.exports = {
+  variableSources: [
+    createOnePasswordResolver({
+      cache: {
+        provider: 'op-cache',
+        ttlSeconds: 300,
+        scope: process.env.OP_CACHE_SCOPE || 'user'
+      }
+    })
+  ]
+}
+```
+
+Only direct secret refs use op-cache in v1:
+
+- `${op://vault/item/field}`
+- `${op(op://vault/item/field)}`
+- aliases whose normalized ref is `{ kind: 'secretRef' }`
+
+Do not cache item JSON reads in v1:
+
+- `${op:itemName}`
+- `${op(item-id).password}`
+- private item links
+
+Reasoning: `op-cache read` is scoped to a single `op://` field. `op item get --reveal` returns a whole item and has field-selection semantics that deserve a separate design.
+
+The plugin retains its current per-process promise cache and cold-start latch. The daemon cache handles cross-process reuse; the promise cache still prevents duplicate work inside one resolution run.
+
+Failure behavior:
+
+- default is fail closed: when the user explicitly requested cache and the daemon/package errors, resolution fails with a clear message;
+- `cache.fallbackToOp: true` opts into the CLI-style degradation for local convenience.
+
+This asymmetry with the CLI is deliberate: the CLI is an interactive/agent tool where a broken cache should never block a secret read, while a config that explicitly declares a cache provider should surface cache breakage instead of masking it.
+
+If `OP_SERVICE_ACCOUNT_TOKEN` is set:
+
+- bypass the cache unless `cache.allowServiceAccountTokenCache === true`;
+- do not hash or log the token.
+
+## Security Requirements
+
+- Secret values never written to disk.
+- Secret values never logged; background daemon writes no log file at all.
+- Raw refs should not appear in cache stats.
+- Socket path must be owned by the current user.
+- Socket permissions must be `0600` on Unix.
+- Daemon refuses unsafe existing sockets where possible.
+- `clear` and `stop` must work even if stats are unavailable.
+- Request line-length limit prevents memory abuse.
+- `max_ttl_seconds` clamp and periodic expiry sweep bound how long a secret can live in daemon memory.
+- `read` stdout is the secret by design; all other output goes to stderr unless command semantics require stdout.
+- Error messages should be sanitized similarly to `packages/configorama/plugins/onepassword/op-cli.js`.
+
+Threat model:
+
+- Same-user processes can generally inspect each other on developer machines, so this is not a hard isolation boundary.
+- The cache reduces repeated auth prompts; it does not make untrusted config safe.
+- Configorama safe mode and audit should continue to flag remote secret reads.
+
+## Testing Plan
+
+Tests use `uvu`, runnable with plain `node path/to/file.test.js`.
+
+Unit tests:
+
+- duration parser;
+- config loading and precedence (flags > env > json file > defaults);
+- missing/invalid config file handling;
+- cache TTL expiration;
+- LRU eviction;
+- scope key generation;
+- session scope precedence (`OP_CACHE_SESSION` over `OP_CACHE_SCOPE`) and bare-session error;
+- account precedence;
+- `OP_ACCOUNT` fallback;
+- op error translation.
+
+Daemon/client integration tests:
+
+- auto-start daemon on `read`;
+- stats/clear/status do not spawn a daemon and report not-running (clear exits 0);
+- read miss calls fake `op`;
+- read hit does not call fake `op`;
+- daemon failure ladder: broken socket -> retry -> direct fake `op` with stderr warning;
+- stats count hits/misses globally;
+- scoped stats report entry counts per scope;
+- clear removes entries;
+- scoped clear removes only that scope;
+- `set` TTL is clamped to `max_ttl_seconds` and the client warns;
+- periodic sweep deletes expired entries without a read;
+- idle daemon exits after `idle_exit_seconds` only when cache is empty;
+- daemon with live entries survives the idle window;
+- `status` reports daemon version and effective config;
+- version mismatch produces a client warning;
+- `OP_CACHE_DISABLED=1` bypasses the daemon entirely;
+- stop shuts daemon down;
+- stale pid file/socket recovery;
+- unsafe socket permission rejection.
+
+CLI tests:
+
+- `read` prints only secret to stdout;
+- `status` reports running/not running;
+- `stats` reports counts without refs or secrets;
+- `--json` output for status/stats/doctor is stable, parseable JSON;
+- `clear` works;
+- win32 passthrough behavior (platform-stubbed): read execs `op` directly, doctor reports caching unavailable.
+
+Configorama integration tests:
+
+- direct `op://` ref uses cache when configured;
+- missing `@davidwells/op-cache` with cache configured errors with install hint;
+- duplicate refs still share in-process promises;
+- cache hit avoids `op read` across two separate resolver invocations;
+- explicit cache failure errors clearly (fail closed);
+- `fallbackToOp` degradation works when enabled;
+- item reads still use normal `op item get`;
+- stdout hygiene remains clean.
+
+Type/check scripts:
+
+- root `npm run typecheck` after code changes;
+- package tests;
+- configorama onepassword tests;
+- configx tests if integration touches configx docs or behavior.
+
+## Migration From Rust Prototype
+
+Feature parity checklist:
+
+- [ ] `read`
+- [ ] `status`
+- [ ] `stats`
+- [ ] `clear`
+- [ ] `stop`
+- [ ] daemon auto-start (read only)
+- [ ] foreground daemon mode
+- [ ] background daemon mode
+- [ ] config file (JSON, optional)
+- [ ] socket path config
+- [ ] TTL config
+- [ ] max entries config
+- [ ] op path config
+- [ ] op timeout config
+- [ ] account flag
+- [ ] ambient `OP_ACCOUNT`
+- [ ] cache key account partitioning
+- [ ] safe socket permissions
+- [ ] no disk persistence for secrets
+
+Intentional JS differences:
+
+- `run` is not ported; configx handles env injection;
+- wire protocol is newline-delimited JSON, not length-prefixed MessagePack;
+- `read` runs `op read --no-newline` instead of trimming trailing whitespace, preserving multiline secrets;
+- config file is JSON, not YAML (same key names);
+- default TTL is 300 seconds, not 86400;
+- default socket path includes the uid;
+- only `read` spawns the daemon; stats/clear report not-running instead;
+- background daemon writes no log file;
+- daemon auto-exits when idle and empty.
+
+New features beyond Rust:
+
+- [ ] per-request TTL
+- [ ] duration syntax
+- [ ] explicit scope string
+- [ ] scoped stats (entry counts)
+- [ ] scoped clear
+- [ ] `max_ttl_seconds` clamp with warning
+- [ ] periodic expiry sweep
+- [ ] idle daemon auto-exit
+- [ ] daemon version/config reporting
+- [ ] daemon failure fallback ladder
+- [ ] `OP_CACHE_DISABLED` bypass
+- [ ] `--json` output for status/stats/doctor
+- [ ] win32 passthrough
+- [ ] `doctor`
+- [ ] Configorama onepassword plugin integration
+
+Coexistence with the Rust binary: both install a bin named `op-cache`, so whichever is first on PATH wins, and different default socket paths mean two daemons with separate caches. The JS package replaces the Rust prototype in daily use; uninstall the Rust binary once the JS package is installed, and say so in the README. `_misc/op-cache` stays in the repo as a design reference only.
+
+## Publishing
+
+- lerna independent versioning; `@davidwells/op-cache` versions on its own, not in lockstep with configorama;
+- public on npm from `0.1.0` — the bin is useful standalone before the plugin integration lands, and 0.x signals the API may still move;
+- LICENSE matches the repo's existing license.
+
+## Implementation Phases
+
+### Phase 0: Baseline
+
+The monorepo restructure has landed on master; confirm the baseline before wiring a new package.
+
+Acceptance:
+
+- root workspace scripts are stable;
+- `packages/configorama` and `packages/configx` paths are final enough for package wiring;
+- existing typecheck/test baseline is known.
+
+### Phase 1: Package Scaffold
+
+Create `packages/op-cache` with package metadata, README, license, CLI entry, and test runner.
+
+Acceptance:
+
+- `pnpm -r --filter @davidwells/op-cache test` runs;
+- `op-cache --help` works from workspace bin;
+- no Configorama integration yet.
+
+### Phase 2: Core Cache and Config
+
+Implement config loading (flags/env/JSON file/defaults), duration parsing, scope parsing, cache key hashing, and the in-memory TTL/LRU cache.
+
+Acceptance:
+
+- unit tests cover TTL, LRU, config precedence, session scope rules, and scope keys;
+- no real `op` invocation in default tests.
+
+### Phase 3: Daemon and Protocol
+
+Implement daemon auto-start, Unix socket server/client, status/stats/clear/stop, TTL clamp, sweep, and idle exit.
+
+Acceptance:
+
+- daemon tests run against temp socket paths;
+- sockets are `0600`;
+- stale socket/pid recovery is covered;
+- TTL clamp, expiry sweep, and idle exit are covered;
+- spawn policy is covered (only read spawns);
+- stats never include refs or values.
+
+### Phase 4: Read Command
+
+Implement `read` with fake-op testability, account/config/op path handling, timeout, sanitized errors, cache get/set, and the daemon failure fallback ladder.
+
+Acceptance:
+
+- first read calls fake `op`;
+- second read hits daemon cache;
+- broken daemon degrades to direct fake `op` with stderr warning;
+- explicit account and ambient `OP_ACCOUNT` partition cache entries;
+- stdout contains only the secret value.
+
+### Phase 5: OnePassword Plugin Integration
+
+Add optional cache support to `packages/configorama/plugins/onepassword` via lazy require.
+
+Acceptance:
+
+- direct secret refs use cache only when configured;
+- no behavior change when cache option is absent;
+- missing package with cache configured errors with install hint;
+- item/private-link reads remain unchanged;
+- fail-closed default and `fallbackToOp` opt-in are covered;
+- stdout hygiene tests still pass;
+- `npm run typecheck` passes.
+
+### Phase 6: Docs and Examples
+
+Document standalone use and Configorama/configx use.
+
+Add example:
+
+```js
+// configx.config.js
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+module.exports = {
+  variableSources: [
+    createOnePasswordResolver({
+      cache: {
+        provider: 'op-cache',
+        ttlSeconds: 300,
+        scope: process.env.OP_CACHE_SCOPE || 'user'
+      }
+    })
+  ]
+}
+```
+
+Acceptance:
+
+- README explains security model;
+- README explains TTL and scope;
+- README tells Rust prototype users to remove the old binary from PATH;
+- Configorama plugin README points to `@davidwells/op-cache`;
+- configx README mentions it only as an optional way to reduce repeated 1Password prompts.

--- a/packages/configorama/package.json
+++ b/packages/configorama/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@cdktf/hcl2json": "^0.21.0",
+    "@davidwells/op-cache": "workspace:^",
     "@types/node": "^24.10.1",
     "markdown-magic": "^4.8.0",
     "tsx": "^4.7.0",
@@ -88,11 +89,15 @@
     "lodash": "^4.18.1"
   },
   "peerDependencies": {
+    "@davidwells/op-cache": ">=0.1.0",
     "@cdktf/hcl2json": ">=0.20.0",
     "ts-node": ">=10.0.0",
     "tsx": ">=4.0.0"
   },
   "peerDependenciesMeta": {
+    "@davidwells/op-cache": {
+      "optional": true
+    },
     "@cdktf/hcl2json": {
       "optional": true
     },

--- a/packages/configorama/plugins/onepassword/README.md
+++ b/packages/configorama/plugins/onepassword/README.md
@@ -50,7 +50,7 @@ Options:
 | `configDir` | string | Passed to `op` as `--config` |
 | `opPath` | string | Path to the `op` binary (defaults to `op` on `PATH`) |
 | `skipResolution` | boolean | Record metadata and return deterministic placeholders without calling `op` |
-| `cache` | object | Optional cache provider config. `{ provider: 'op-cache' }` enables `@davidwells/op-cache` for direct `op://` reads only |
+| `cache` | object | Optional cache provider config. `{ provider: 'op-cache' }` enables `@davidwells/op-cache` for every supported `${op...}` syntax |
 
 ## Alias syntax (recommended)
 
@@ -187,9 +187,22 @@ module.exports = {
 }
 ```
 
-Only direct secret references are cached in v1: `${op://vault/item/field}`, `${op(op://vault/item/field)}`, and aliases that point to an `op://` ref. Item JSON reads, private links, and field-inference reads still use the normal `op item get --reveal` path.
+Every supported syntax caches when the cache option is configured — aliases, item names and IDs, private links, explicit fields, inferred fields, and structured note key paths, plus direct `op://` refs:
 
-The plugin fails closed by default when a configured cache provider is broken. Set `fallbackToOp: true` to degrade to direct `op read`. If `OP_SERVICE_ACCOUNT_TOKEN` is set, the cache is bypassed unless `allowServiceAccountTokenCache: true` is configured.
+```yaml
+a: ${op:npm.NPM_TOKEN}            # alias + structured note key path
+b: ${op(database-prod).password}  # item name + field
+c: ${op(<private link>).KEY}      # private link + key
+d: ${op(op://vault/item/field)}   # direct secret ref
+```
+
+The cache stores **final resolved values only**, never `op item get` JSON. A cached entry is exactly the string a variable resolved to, so the daemon never holds more secret material than a config actually requested, and a cache hit returns the value without any `op` call. Item JSON is deliberately not cached: whole items hold every revealed field, complicate invalidation, and would turn the cache into something 1Password-shape-aware instead of a scalar secret store.
+
+One granularity consequence: `${op(op://vault/item/notesPlain).KEY}` caches the selected `KEY` value, not the whole `notesPlain` field. Resolving a key path that no earlier run resolved costs one fresh `op` call even when a sibling key is already cached.
+
+Values live in daemon memory only — until TTL expiry, `op-cache clear`, or `op-cache stop`; nothing is written to disk. Short TTLs (minutes, not hours) are recommended for interactive agent workflows. `OP_CACHE_DISABLED=1` bypasses all cache paths.
+
+The plugin fails closed by default when a configured cache provider is broken. Set `fallbackToOp: true` to degrade to direct resolution. If `OP_SERVICE_ACCOUNT_TOKEN` is set, the cache is bypassed unless `allowServiceAccountTokenCache: true` is configured.
 
 ## Security model
 

--- a/packages/configorama/plugins/onepassword/README.md
+++ b/packages/configorama/plugins/onepassword/README.md
@@ -50,6 +50,7 @@ Options:
 | `configDir` | string | Passed to `op` as `--config` |
 | `opPath` | string | Path to the `op` binary (defaults to `op` on `PATH`) |
 | `skipResolution` | boolean | Record metadata and return deterministic placeholders without calling `op` |
+| `cache` | object | Optional cache provider config. `{ provider: 'op-cache' }` enables `@davidwells/op-cache` for direct `op://` reads only |
 
 ## Alias syntax (recommended)
 
@@ -159,6 +160,36 @@ configorama: requesting 3 items from 1Password (expect an authorization prompt)
 ```
 
 The hint is TTY-only — silent in CI and pipes.
+
+## Optional op-cache
+
+For fresh-process workflows such as agents repeatedly running `configx .env -- <command>`, install `@davidwells/op-cache` and opt in explicitly:
+
+```bash
+npm install @davidwells/op-cache
+```
+
+```js
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+module.exports = {
+  variableSources: [
+    createOnePasswordResolver({
+      cache: {
+        provider: 'op-cache',
+        ttlSeconds: 300,
+        scope: process.env.OP_CACHE_SCOPE || 'user',
+        fallbackToOp: false,
+        allowServiceAccountTokenCache: false
+      }
+    })
+  ]
+}
+```
+
+Only direct secret references are cached in v1: `${op://vault/item/field}`, `${op(op://vault/item/field)}`, and aliases that point to an `op://` ref. Item JSON reads, private links, and field-inference reads still use the normal `op item get --reveal` path.
+
+The plugin fails closed by default when a configured cache provider is broken. Set `fallbackToOp: true` to degrade to direct `op read`. If `OP_SERVICE_ACCOUNT_TOKEN` is set, the cache is bypassed unless `allowServiceAccountTokenCache: true` is configured.
 
 ## Security model
 

--- a/packages/configorama/plugins/onepassword/cache-ref.js
+++ b/packages/configorama/plugins/onepassword/cache-ref.js
@@ -1,0 +1,34 @@
+/* Builds synthetic cache refs for final-value op-cache entries.
+   NUL-joined fixed-order dimensions hashed with SHA-256 — never raw links. */
+const crypto = require('crypto')
+
+// Bump whenever field-selection semantics or the envelope shape change:
+// old entries then live under unreachable keys and expire unread.
+const CACHE_REF_SCHEMA_VERSION = 'v1'
+
+/**
+ * Deterministic cache reference for one final-value resolver operation.
+ * Dimensions are requested inputs only — never discovered outputs — so the
+ * key is computable before any op call. account/configDir/opPath are NOT
+ * included here; they travel via getOrSet opts and op-cache applies them as
+ * key dimensions, exactly as it does for read (one owner per dimension).
+ * @param {object} reference - Normalized reference ({ kind, item, vault, section, field, ref })
+ * @param {string|undefined} keyPath - Requested key path
+ * @returns {string} configorama-op://v1/<sha256hex>
+ */
+function buildCacheRef(reference, keyPath) {
+  const itemOrRef = reference.kind === 'secretRef' ? reference.ref : reference.item
+  const parts = [
+    CACHE_REF_SCHEMA_VERSION,
+    reference.kind || '',
+    itemOrRef || '',
+    reference.vault || '',
+    reference.section || '',
+    reference.field || '',
+    keyPath || '',
+  ]
+  const hash = crypto.createHash('sha256').update(parts.join('\0')).digest('hex')
+  return `configorama-op://${CACHE_REF_SCHEMA_VERSION}/${hash}`
+}
+
+module.exports = { buildCacheRef, CACHE_REF_SCHEMA_VERSION }

--- a/packages/configorama/plugins/onepassword/cache-ref.test.js
+++ b/packages/configorama/plugins/onepassword/cache-ref.test.js
@@ -1,0 +1,61 @@
+/* Tests for synthetic cache ref construction.
+   Keys must be stable, collision-free per dimension, and never contain raw links. */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const { buildCacheRef, CACHE_REF_SCHEMA_VERSION } = require('./cache-ref')
+
+const itemRef = { kind: 'item', item: 'database-prod', vault: 'infra', section: undefined, field: 'password' }
+
+test('same inputs produce the same ref', () => {
+  const a = buildCacheRef(itemRef, 'database.password')
+  const b = buildCacheRef({ ...itemRef }, 'database.password')
+  assert.is(a, b)
+})
+
+test('ref shape is configorama-op://<version>/<sha256hex>', () => {
+  const ref = buildCacheRef(itemRef, undefined)
+  assert.match(ref, new RegExp(`^configorama-op://${CACHE_REF_SCHEMA_VERSION}/[0-9a-f]{64}$`))
+})
+
+test('every dimension change produces a different ref', () => {
+  const base = buildCacheRef(itemRef, 'k')
+  const variants = [
+    buildCacheRef({ ...itemRef, kind: 'privateLink' }, 'k'),
+    buildCacheRef({ ...itemRef, item: 'other-item' }, 'k'),
+    buildCacheRef({ ...itemRef, vault: 'other-vault' }, 'k'),
+    buildCacheRef({ ...itemRef, section: 'a-section' }, 'k'),
+    buildCacheRef({ ...itemRef, field: 'username' }, 'k'),
+    buildCacheRef(itemRef, 'other.key'),
+    buildCacheRef(itemRef, undefined),
+  ]
+  const all = new Set([base, ...variants])
+  assert.is(all.size, variants.length + 1)
+})
+
+test('secretRef uses the op:// ref as the item dimension', () => {
+  const a = buildCacheRef({ kind: 'secretRef', ref: 'op://vault/item/notesPlain' }, 'KEY')
+  const b = buildCacheRef({ kind: 'secretRef', ref: 'op://vault/item/other' }, 'KEY')
+  assert.is.not(a, b)
+})
+
+test('adjacent dimensions cannot collide via separator ambiguity', () => {
+  // item "a" + vault "b" must differ from item "ab" + vault ""
+  const a = buildCacheRef({ kind: 'item', item: 'a', vault: 'b' }, undefined)
+  const b = buildCacheRef({ kind: 'item', item: 'ab', vault: undefined }, undefined)
+  assert.is.not(a, b)
+})
+
+test('private link refs contain no URL fragments', () => {
+  // normalize.js reduces private links to item/vault IDs before this point
+  const ref = buildCacheRef({ kind: 'privateLink', item: 'abc123def456ghij789klm2345', vault: 'vaultid123' }, 'NPM_TOKEN')
+  assert.not.match(ref, /https?:|start\.1password|%2F/i)
+  assert.match(ref, /^configorama-op:\/\/v1\/[0-9a-f]{64}$/)
+})
+
+test('undefined and empty-string dimensions are equivalent and stable', () => {
+  const a = buildCacheRef({ kind: 'item', item: 'x', vault: undefined, section: undefined, field: undefined }, undefined)
+  const b = buildCacheRef({ kind: 'item', item: 'x', vault: '', section: '', field: '' }, undefined)
+  assert.is(a, b)
+})
+
+test.run()

--- a/packages/configorama/plugins/onepassword/envelope.js
+++ b/packages/configorama/plugins/onepassword/envelope.js
@@ -1,0 +1,45 @@
+/* Encodes cached final values as { value, fieldName } JSON strings.
+   Private plugin convention: op-cache stores these as opaque strings. */
+
+/**
+ * @param {string} value - Final resolved value
+ * @param {string|undefined} fieldName - Discovered field name for audit metadata
+ * @returns {string} Envelope JSON string
+ */
+function encodeEnvelope(value, fieldName) {
+  if (typeof value !== 'string') throw new Error('Envelope value must be a string.')
+  return JSON.stringify(fieldName === undefined ? { value } : { value, fieldName })
+}
+
+/**
+ * @param {string} encoded - Envelope JSON string
+ * @returns {{value: string, fieldName: string|undefined}}
+ */
+function decodeEnvelope(encoded) {
+  let parsed
+  try {
+    parsed = JSON.parse(encoded)
+  } catch (err) {
+    throw new Error('Malformed op-cache envelope: not valid JSON.')
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || typeof parsed.value !== 'string') {
+    throw new Error('Malformed op-cache envelope: missing string value.')
+  }
+  return { value: parsed.value, fieldName: typeof parsed.fieldName === 'string' ? parsed.fieldName : undefined }
+}
+
+/**
+ * validateCached hook: rejecting here makes getOrSet recompute and overwrite.
+ * @param {string} encoded - Cached string
+ * @returns {boolean}
+ */
+function isValidEnvelope(encoded) {
+  try {
+    decodeEnvelope(encoded)
+    return true
+  } catch (err) {
+    return false
+  }
+}
+
+module.exports = { encodeEnvelope, decodeEnvelope, isValidEnvelope }

--- a/packages/configorama/plugins/onepassword/envelope.test.js
+++ b/packages/configorama/plugins/onepassword/envelope.test.js
@@ -1,0 +1,53 @@
+/* Tests for the cached-value envelope: { value, fieldName } as a JSON string.
+   The envelope is a private plugin convention; op-cache stores opaque strings. */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const { encodeEnvelope, decodeEnvelope, isValidEnvelope } = require('./envelope')
+
+test('round-trip preserves value byte-exact and fieldName', () => {
+  const decoded = decodeEnvelope(encodeEnvelope('s3cr3t-value', 'credential'))
+  assert.is(decoded.value, 's3cr3t-value')
+  assert.is(decoded.fieldName, 'credential')
+})
+
+test('round-trip preserves values that look like JSON', () => {
+  const tricky = '{"value":"fake","fieldName":"fake"}'
+  const decoded = decodeEnvelope(encodeEnvelope(tricky, 'notesPlain'))
+  assert.is(decoded.value, tricky)
+})
+
+test('round-trip preserves multiline and empty values', () => {
+  const multiline = 'line one\nline two\n'
+  assert.is(decodeEnvelope(encodeEnvelope(multiline, 'notesPlain')).value, multiline)
+  assert.is(decodeEnvelope(encodeEnvelope('', 'password')).value, '')
+})
+
+test('fieldName is optional', () => {
+  const decoded = decodeEnvelope(encodeEnvelope('v', undefined))
+  assert.is(decoded.value, 'v')
+  assert.is(decoded.fieldName, undefined)
+})
+
+test('encode requires a string value', () => {
+  assert.throws(() => encodeEnvelope(42, 'f'), /string/)
+  assert.throws(() => encodeEnvelope(undefined, 'f'), /string/)
+})
+
+test('isValidEnvelope accepts encoded envelopes and rejects malformed input', () => {
+  assert.ok(isValidEnvelope(encodeEnvelope('v', 'f')))
+  assert.ok(isValidEnvelope(encodeEnvelope('v', undefined)))
+  assert.not.ok(isValidEnvelope('raw-secret-value'))
+  assert.not.ok(isValidEnvelope('{"truncated":'))
+  assert.not.ok(isValidEnvelope('{"fieldName":"f"}'))
+  assert.not.ok(isValidEnvelope('{"value":42}'))
+  assert.not.ok(isValidEnvelope('[]'))
+  assert.not.ok(isValidEnvelope('null'))
+  assert.not.ok(isValidEnvelope(''))
+})
+
+test('decodeEnvelope throws on malformed input rather than returning junk', () => {
+  assert.throws(() => decodeEnvelope('not-json'), /envelope/i)
+  assert.throws(() => decodeEnvelope('{"value":42}'), /envelope/i)
+})
+
+test.run()

--- a/packages/configorama/plugins/onepassword/index.js
+++ b/packages/configorama/plugins/onepassword/index.js
@@ -4,6 +4,8 @@ const { readSecretRef, getItem } = require('./op-cli')
 const { validateAliasName, normalizeRefValue, isItemId } = require('./normalize')
 const { selectField, trySelectField } = require('./fields')
 const { parseStructuredSecret, getKeyPath } = require('./parser')
+const { buildCacheRef } = require('./cache-ref')
+const { encodeEnvelope, decodeEnvelope, isValidEnvelope } = require('./envelope')
 
 const OP_PREFIX = 'op'
 
@@ -212,6 +214,75 @@ function createOnePasswordResolver(options = {}) {
   }
 
   /**
+   * Resolve a normalized reference to its final value.
+   * Direct secret refs without a key path keep the read path (same daemon
+   * keys as standalone `op-cache read`); every other syntax caches its
+   * final resolved value under a synthetic ref.
+   * @param {object} reference - Normalized reference
+   * @param {string|undefined} keyPath - Requested key path
+   * @param {string} [label] - Human label for the auth hint
+   * @returns {Promise<{value: string, fieldName: string|undefined}>} Final value
+   */
+  async function resolveReference(reference, keyPath, label) {
+    if (reference.kind === 'secretRef' && keyPath === undefined) {
+      const value = await cached(secretRefCache, `${scopeKey}|${reference.ref}`, () => {
+        return readSecretRefWithOptionalCache(reference.ref)
+      }, label)
+      return { value, fieldName: undefined }
+    }
+    return finalValueWithOptionalCache(reference, keyPath, label)
+  }
+
+  /**
+   * Final-value caching through op-cache getOrSet. The cached payload is a
+   * { value, fieldName } envelope so audit metadata survives cache hits;
+   * malformed envelopes are rejected via validateCached and recomputed.
+   * @param {object} reference - Normalized reference
+   * @param {string|undefined} keyPath - Requested key path
+   * @param {string} [label] - Human label for the auth hint
+   * @returns {Promise<{value: string, fieldName: string|undefined}>} Final value
+   */
+  async function finalValueWithOptionalCache(reference, keyPath, label) {
+    if (!opCache || shouldBypassOpCache()) {
+      return computeFinalValue(reference, keyPath, label)
+    }
+    const cacheRef = buildCacheRef(reference, keyPath)
+    const encoded = await opCache.getOrSet(cacheRef, async () => {
+      const resolved = await computeFinalValue(reference, keyPath, label)
+      return encodeEnvelope(resolved.value, resolved.fieldName)
+    }, {
+      account,
+      configDir,
+      opPath,
+      ttlSeconds: cache.ttlSeconds,
+      scope: cache.scope,
+      fallbackToOp: cache.fallbackToOp === true,
+      validateCached: isValidEnvelope,
+      stderr: process.stderr,
+    })
+    return decodeEnvelope(encoded)
+  }
+
+  /**
+   * Compute the final resolver value with no persistent cache involved.
+   * This is the getOrSet producer body; the cold-start latch lives in here
+   * (via cached) so daemon hits never serialize behind it and auth hints
+   * only print when an op call actually happens.
+   * @param {object} reference - Normalized reference
+   * @param {string|undefined} keyPath - Requested key path
+   * @param {string} [label] - Human label for the auth hint
+   * @returns {Promise<{value: string, fieldName: string|undefined}>} Final value
+   */
+  async function computeFinalValue(reference, keyPath, label) {
+    const { value, fieldName, remainingKeyPath } = await selectBackingValue(reference, keyPath, label)
+    if (remainingKeyPath === undefined) {
+      return { value, fieldName }
+    }
+    const parsedValue = parseStructuredSecret(value, { fieldName })
+    return { value: getKeyPath(parsedValue, remainingKeyPath, fieldName), fieldName }
+  }
+
+  /**
    * Fetch and select the backing field value for a normalized reference.
    * For items without a configured field, the first key path segment may
    * select a field directly: ${op(My Login).password} picks the password
@@ -222,10 +293,10 @@ function createOnePasswordResolver(options = {}) {
    * @param {string} [label] - Human label for the auth hint
    * @returns {Promise<{value: string, fieldName: string, remainingKeyPath: string|undefined}>} Selected value
    */
-  async function fetchValue(reference, keyPath, label) {
+  async function selectBackingValue(reference, keyPath, label) {
     if (reference.kind === 'secretRef') {
       const value = await cached(secretRefCache, `${scopeKey}|${reference.ref}`, () => {
-        return readSecretRefWithOptionalCache(reference.ref)
+        return readSecretRef(reference.ref, cliOptions)
       }, label)
       return { value, fieldName: reference.ref, remainingKeyPath: keyPath }
     }
@@ -305,16 +376,11 @@ function createOnePasswordResolver(options = {}) {
       || (configPath ? configPath.split('.').pop() : undefined)
       || reference.field
       || (reference.kind === 'secretRef' ? reference.ref : reference.item)
-    const { value, fieldName, remainingKeyPath } = await fetchValue(reference, keyPath, label)
-    if (entry.field === undefined && reference.kind !== 'secretRef') {
-      entry.field = fieldName
+    const resolved = await resolveReference(reference, keyPath, label)
+    if (entry.field === undefined && reference.kind !== 'secretRef' && resolved.fieldName !== undefined) {
+      entry.field = resolved.fieldName
     }
-
-    if (remainingKeyPath === undefined) {
-      return value
-    }
-    const parsedValue = parseStructuredSecret(value, { fieldName })
-    return getKeyPath(parsedValue, remainingKeyPath, fieldName)
+    return resolved.value
   }
 
   return {

--- a/packages/configorama/plugins/onepassword/index.js
+++ b/packages/configorama/plugins/onepassword/index.js
@@ -45,6 +45,7 @@ const opVariableSyntax = /^op(?::|\()/
  * @param {string} [options.opPath] - Path to the op binary (defaults to "op" on PATH)
  * @param {string} [options.programName] - Host tool name for the auth-prompt hint (defaults to $CONFIGORAMA_PROGRAM_NAME or "configorama")
  * @param {boolean} [options.skipResolution] - Collect metadata and return placeholders without calling op
+ * @param {object} [options.cache] - Optional cache provider config ({ provider: 'op-cache', ttlSeconds, scope, fallbackToOp, allowServiceAccountTokenCache })
  * @param {Function} [options.execFile] - execFile injection for tests (not serializable; unavailable in sync mode)
  * @returns {object} Variable source configuration with resolver and metadata collector
  */
@@ -56,8 +57,11 @@ function createOnePasswordResolver(options = {}) {
     opPath,
     programName,
     skipResolution = false,
+    cache,
     execFile,
   } = options
+
+  const opCache = cache && cache.provider === 'op-cache' ? loadOpCache() : undefined
 
   const aliasRefs = {}
   for (const alias of Object.keys(refs)) {
@@ -221,7 +225,7 @@ function createOnePasswordResolver(options = {}) {
   async function fetchValue(reference, keyPath, label) {
     if (reference.kind === 'secretRef') {
       const value = await cached(secretRefCache, `${scopeKey}|${reference.ref}`, () => {
-        return readSecretRef(reference.ref, cliOptions)
+        return readSecretRefWithOptionalCache(reference.ref)
       }, label)
       return { value, fieldName: reference.ref, remainingKeyPath: keyPath }
     }
@@ -342,6 +346,7 @@ function createOnePasswordResolver(options = {}) {
    */
   function buildSyncOptions() {
     const syncOptions = { refs, account, configDir, opPath, skipResolution }
+    if (cache !== undefined) syncOptions.cache = cache
     if (execFile) {
       // Functions cannot cross the JSON boundary into the sync worker;
       // flag it so sync-factory can fail loudly instead of silently
@@ -349,6 +354,48 @@ function createOnePasswordResolver(options = {}) {
       syncOptions.hasInjectedExecFile = true
     }
     return syncOptions
+  }
+
+  /**
+   * @param {string} ref - Direct op:// secret reference
+   * @returns {Promise<string>} Secret value
+   */
+  function readSecretRefWithOptionalCache(ref) {
+    if (!opCache || shouldBypassOpCache()) {
+      return readSecretRef(ref, cliOptions)
+    }
+    return opCache.read(ref, {
+      account,
+      configDir,
+      opPath,
+      ttlSeconds: cache.ttlSeconds,
+      scope: cache.scope,
+      fallbackToOp: cache.fallbackToOp === true,
+      stderr: process.stderr,
+    })
+  }
+
+  /**
+   * @returns {boolean} Whether cache must be bypassed for this read
+   */
+  function shouldBypassOpCache() {
+    if (process.env.OP_CACHE_DISABLED === '1') return true
+    if (execFile) return true
+    if (process.env.OP_SERVICE_ACCOUNT_TOKEN && !(cache && cache.allowServiceAccountTokenCache === true)) {
+      return true
+    }
+    return false
+  }
+}
+
+/**
+ * @returns {object} @davidwells/op-cache API
+ */
+function loadOpCache() {
+  try {
+    return require('@davidwells/op-cache')
+  } catch (err) {
+    throw new Error('1Password op-cache provider requested but @davidwells/op-cache is not installed. Install it with: npm install @davidwells/op-cache')
   }
 }
 

--- a/packages/configorama/plugins/onepassword/op-cache-regression.test.js
+++ b/packages/configorama/plugins/onepassword/op-cache-regression.test.js
@@ -1,0 +1,120 @@
+/* Cross-process prompt-reduction regression: all four syntax families resolve
+   with zero op invocations in a second process. Fake op only; never real 1Password. */
+
+// Real manual QA (real 1Password is manual-only, never in CI):
+//   op-cache stop
+//   configx .env -- node <script>   # may prompt
+//   configx .env -- node <script>   # should not prompt within TTL
+//   op-cache stats --json           # shows entries and hits
+//   op-cache stop
+// OP_CACHE_DISABLED=1 restores the old prompt-every-run behavior.
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const childProcess = require('child_process')
+
+const LINK_ITEM_ID = 'abcdefghijklmnopqrstuvwxyz'
+const INI_NOTE = 'NPM_TOKEN=npm-secret\n\n[database]\npassword=db-pass\n'
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-op-regression-'))
+}
+
+function fakeOp(dir) {
+  const bin = path.join(dir, 'fake-op.js')
+  const count = path.join(dir, 'count.txt')
+  fs.writeFileSync(count, '')
+  fs.writeFileSync(bin, `#!/usr/bin/env node
+const fs = require('fs')
+// Concurrent op processes increment in parallel; O_APPEND is atomic where
+// read-modify-write of a counter is not.
+fs.appendFileSync(${JSON.stringify(count)}, '.')
+const args = process.argv.slice(2)
+if (args[0] === 'read') {
+  process.stdout.write('direct-secret')
+  process.exit(0)
+}
+if (args[0] === 'item') {
+  const id = args[2]
+  const itemFields = {
+    'note-item': [{ id: 'notesPlain', type: 'STRING', purpose: 'NOTES', label: 'notesPlain', value: ${JSON.stringify(INI_NOTE)} }],
+    ${JSON.stringify(LINK_ITEM_ID)}: [{ id: 'credential', type: 'CONCEALED', label: 'credential', value: 'link-secret' }],
+  }
+  const fields = itemFields[id] || [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'item-secret' }]
+  process.stdout.write(JSON.stringify({ id, title: id, fields }))
+  process.exit(0)
+}
+process.stderr.write('unknown fake op command')
+process.exit(1)
+`)
+  fs.chmodSync(bin, 0o755)
+  return { bin, calls: () => fs.readFileSync(count, 'utf8').length }
+}
+
+test('second process resolves every syntax family with zero op invocations', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = {
+    ...process.env,
+    OP_CACHE_SOCKET_PATH: path.join(dir, 'cache.sock'),
+    OP_CACHE_OP_PATH: fake.bin,
+    OP_CACHE_TTL_SECONDS: '30',
+    OP_CACHE_MAX_TTL_SECONDS: '30',
+    OP_CACHE_IDLE_EXIT_SECONDS: '10',
+    XDG_CONFIG_HOME: path.join(dir, 'xdg'),
+  }
+  delete env.OP_CACHE_DISABLED
+  delete env.OP_SERVICE_ACCOUNT_TOKEN
+  const link = `https://start.1password.com/open/i?a=ACCOUNT&v=vaultid123&i=${LINK_ITEM_ID}&h=my.1password.com`
+  const code = `
+const configorama = require('./src')
+const createOnePasswordResolver = require('./plugins/onepassword')
+const source = createOnePasswordResolver({
+  refs: { npm: 'note-item' },
+  opPath: process.env.OP_CACHE_OP_PATH,
+  cache: { provider: 'op-cache', ttlSeconds: 30, scope: 'session:regression' }
+})
+configorama({
+  a: '\${op:npm.NPM_TOKEN}',
+  b: '\${op(database-prod).password}',
+  c: '\${op(${link}).credential}',
+  d: '\${op(op://vault/item/field)}'
+}, { variableSources: [source] }).then((config) => {
+  process.stdout.write(JSON.stringify(config))
+}).catch((err) => {
+  process.stderr.write(err.stack || err.message)
+  process.exit(1)
+})
+`
+  const expected = { a: 'npm-secret', b: 'item-secret', c: 'link-secret', d: 'direct-secret' }
+  try {
+    const first = childProcess.spawnSync(process.execPath, ['-e', code], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+    assert.is(first.status, 0, first.stderr)
+    // stdout is exactly the resolved config - no cache chatter
+    assert.equal(JSON.parse(first.stdout), expected)
+    // one op invocation per distinct backing operation: two item gets, one
+    // private-link item get, one op read
+    assert.is(fake.calls(), 4)
+
+    const second = childProcess.spawnSync(process.execPath, ['-e', code], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+    assert.is(second.status, 0, second.stderr)
+    assert.equal(JSON.parse(second.stdout), expected)
+    assert.is(fake.calls(), 4)
+
+    const stats = childProcess.spawnSync(
+      process.execPath,
+      [require.resolve('@davidwells/op-cache/src/cli'), 'stats', '--json'],
+      { env, encoding: 'utf8' }
+    )
+    assert.is(stats.status, 0, stats.stderr)
+    const parsed = JSON.parse(stats.stdout)
+    assert.is(parsed.entries, 4)
+    assert.ok(parsed.hits >= 4, `expected >=4 hits, saw ${parsed.hits}`)
+  } finally {
+    childProcess.spawnSync(process.execPath, [require.resolve('@davidwells/op-cache/src/cli'), 'stop'], { env, encoding: 'utf8' })
+  }
+})
+
+test.run()

--- a/packages/configorama/plugins/onepassword/op-cache.test.js
+++ b/packages/configorama/plugins/onepassword/op-cache.test.js
@@ -1,0 +1,205 @@
+/* Integration tests for optional @davidwells/op-cache support.
+   Uses a fake op binary and temp daemon sockets; never calls real 1Password. */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const childProcess = require('child_process')
+const Module = require('module')
+const configorama = require('../../src')
+const createOnePasswordResolver = require('./index')
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-op-cache-'))
+}
+
+function fakeOp(dir) {
+  const bin = path.join(dir, 'fake-op.js')
+  const count = path.join(dir, 'count.txt')
+  fs.writeFileSync(count, '0')
+  fs.writeFileSync(bin, `#!/usr/bin/env node
+const fs = require('fs')
+const count = ${JSON.stringify(count)}
+const n = Number(fs.readFileSync(count, 'utf8') || '0') + 1
+fs.writeFileSync(count, String(n))
+const args = process.argv.slice(2)
+if (process.env.FAKE_OP_FAIL) {
+  process.stderr.write(process.env.FAKE_OP_FAIL)
+  process.exit(1)
+}
+if (args[0] === 'read') {
+  process.stdout.write(process.env.FAKE_OP_VALUE || 'cached-secret')
+  process.exit(0)
+}
+if (args[0] === 'item') {
+  process.stdout.write(JSON.stringify({
+    id: args[2],
+    title: args[2],
+    fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'item-secret' }]
+  }))
+  process.exit(0)
+}
+process.stderr.write('unknown fake op command')
+process.exit(1)
+`)
+  fs.chmodSync(bin, 0o755)
+  return { bin, calls: () => Number(fs.readFileSync(count, 'utf8') || '0') }
+}
+
+function envFor(dir, fake) {
+  return {
+    ...process.env,
+    OP_CACHE_SOCKET_PATH: path.join(dir, 'cache.sock'),
+    OP_CACHE_OP_PATH: fake.bin,
+    OP_CACHE_TTL_SECONDS: '2',
+    OP_CACHE_MAX_TTL_SECONDS: '2',
+    OP_CACHE_IDLE_EXIT_SECONDS: '1',
+    XDG_CONFIG_HOME: path.join(dir, 'xdg'),
+  }
+}
+
+function stop(env) {
+  childProcess.spawnSync(process.execPath, [require.resolve('@davidwells/op-cache/src/cli'), 'stop'], { env, encoding: 'utf8' })
+}
+
+async function resolveWithCache(fake, cache) {
+  const source = createOnePasswordResolver({ opPath: fake.bin, cache })
+  return configorama({ token: '${op://vault/item/field}' }, { variableSources: [source] })
+}
+
+test('direct op:// refs use op-cache across separate processes when configured', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const code = `
+const configorama = require('./src')
+const createOnePasswordResolver = require('./plugins/onepassword')
+configorama(
+  { token: '\${op://vault/item/field}' },
+  { variableSources: [createOnePasswordResolver({
+    opPath: process.env.OP_CACHE_OP_PATH,
+    cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:cross-process' }
+  })] }
+).then((config) => process.stdout.write(config.token)).catch((err) => {
+  process.stderr.write(err.stack || err.message)
+  process.exit(1)
+})
+`
+  try {
+    const first = childProcess.spawnSync(process.execPath, ['-e', code], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+    assert.is(first.status, 0, first.stderr)
+    assert.is(first.stdout, 'cached-secret')
+    const second = childProcess.spawnSync(process.execPath, ['-e', code], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+    assert.is(second.status, 0, second.stderr)
+    assert.is(second.stdout, 'cached-secret')
+    assert.is(fake.calls(), 1)
+  } finally {
+    stop(env)
+  }
+})
+
+test('no cache option preserves existing direct op behavior', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const source = createOnePasswordResolver({ opPath: fake.bin })
+  const config = await configorama({ token: '${op://vault/item/field}' }, { variableSources: [source] })
+  assert.is(config.token, 'cached-secret')
+  assert.is(fake.calls(), 1)
+})
+
+test('item reads do not use op-cache daemon', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const prior = process.env.OP_CACHE_SOCKET_PATH
+  const priorOp = process.env.OP_CACHE_OP_PATH
+  process.env.OP_CACHE_SOCKET_PATH = env.OP_CACHE_SOCKET_PATH
+  process.env.OP_CACHE_OP_PATH = fake.bin
+  try {
+    const source = createOnePasswordResolver({
+      opPath: fake.bin,
+      cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:item-bypass' },
+    })
+    const config = await configorama({ password: '${op(database-prod).password}' }, { variableSources: [source] })
+    assert.is(config.password, 'item-secret')
+    assert.is(fake.calls(), 1)
+    assert.is(fs.existsSync(env.OP_CACHE_SOCKET_PATH), false)
+  } finally {
+    if (prior === undefined) delete process.env.OP_CACHE_SOCKET_PATH
+    else process.env.OP_CACHE_SOCKET_PATH = prior
+    if (priorOp === undefined) delete process.env.OP_CACHE_OP_PATH
+    else process.env.OP_CACHE_OP_PATH = priorOp
+    stop(env)
+  }
+})
+
+test('OP_SERVICE_ACCOUNT_TOKEN bypasses cache unless explicitly allowed', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const priorToken = process.env.OP_SERVICE_ACCOUNT_TOKEN
+  const priorSocket = process.env.OP_CACHE_SOCKET_PATH
+  process.env.OP_SERVICE_ACCOUNT_TOKEN = 'token-value'
+  process.env.OP_CACHE_SOCKET_PATH = env.OP_CACHE_SOCKET_PATH
+  try {
+    await resolveWithCache(fake, { provider: 'op-cache', ttlSeconds: 2, scope: 'session:token' })
+    await resolveWithCache(fake, { provider: 'op-cache', ttlSeconds: 2, scope: 'session:token' })
+    assert.is(fake.calls(), 2)
+  } finally {
+    if (priorToken === undefined) delete process.env.OP_SERVICE_ACCOUNT_TOKEN
+    else process.env.OP_SERVICE_ACCOUNT_TOKEN = priorToken
+    if (priorSocket === undefined) delete process.env.OP_CACHE_SOCKET_PATH
+    else process.env.OP_CACHE_SOCKET_PATH = priorSocket
+    stop(env)
+  }
+})
+
+test('cache failure fails closed by default and fallbackToOp degrades when enabled', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const badSocket = path.join(dir, 'not-a-socket')
+  fs.writeFileSync(badSocket, 'x')
+  const priorSocket = process.env.OP_CACHE_SOCKET_PATH
+  process.env.OP_CACHE_SOCKET_PATH = badSocket
+  try {
+    try {
+      await resolveWithCache(fake, { provider: 'op-cache', ttlSeconds: 2, scope: 'session:bad' })
+      assert.unreachable('should fail closed')
+    } catch (err) {
+      assert.match(err.message, /Unsafe op-cache socket|failed to start|socket/)
+    }
+    const written = []
+    const originalWrite = process.stderr.write
+    process.stderr.write = (chunk) => { written.push(String(chunk)); return true }
+    try {
+      const config = await resolveWithCache(fake, { provider: 'op-cache', ttlSeconds: 2, scope: 'session:bad', fallbackToOp: true })
+      assert.is(config.token, 'cached-secret')
+    } finally {
+      process.stderr.write = originalWrite
+    }
+    assert.ok(written.join('').includes('cache bypassed'))
+  } finally {
+    if (priorSocket === undefined) delete process.env.OP_CACHE_SOCKET_PATH
+    else process.env.OP_CACHE_SOCKET_PATH = priorSocket
+  }
+})
+
+test('missing op-cache package with cache configured gives install hint', () => {
+  const originalLoad = Module._load
+  Module._load = function patched(request) {
+    if (request === '@davidwells/op-cache') {
+      const err = new Error('Cannot find module')
+      err.code = 'MODULE_NOT_FOUND'
+      throw err
+    }
+    return originalLoad.apply(this, arguments)
+  }
+  try {
+    assert.throws(() => createOnePasswordResolver({ cache: { provider: 'op-cache' } }), /npm install @davidwells\/op-cache/)
+  } finally {
+    Module._load = originalLoad
+  }
+})
+
+test.run()

--- a/packages/configorama/plugins/onepassword/op-cache.test.js
+++ b/packages/configorama/plugins/onepassword/op-cache.test.js
@@ -20,12 +20,12 @@ const INI_NOTE = 'NPM_TOKEN=npm-secret\n\n[database]\npassword=db-pass\n'
 function fakeOp(dir) {
   const bin = path.join(dir, 'fake-op.js')
   const count = path.join(dir, 'count.txt')
-  fs.writeFileSync(count, '0')
+  fs.writeFileSync(count, '')
   fs.writeFileSync(bin, `#!/usr/bin/env node
 const fs = require('fs')
-const count = ${JSON.stringify(count)}
-const n = Number(fs.readFileSync(count, 'utf8') || '0') + 1
-fs.writeFileSync(count, String(n))
+// O_APPEND is atomic under concurrent op processes; a read-modify-write
+// counter loses increments when resolution fans out in parallel.
+fs.appendFileSync(${JSON.stringify(count)}, '.')
 const args = process.argv.slice(2)
 if (process.env.FAKE_OP_FAIL) {
   process.stderr.write(process.env.FAKE_OP_FAIL)
@@ -58,7 +58,7 @@ process.stderr.write('unknown fake op command')
 process.exit(1)
 `)
   fs.chmodSync(bin, 0o755)
-  return { bin, calls: () => Number(fs.readFileSync(count, 'utf8') || '0') }
+  return { bin, calls: () => fs.readFileSync(count, 'utf8').length }
 }
 
 // op-cache memoizes env-derived config per process; in-process daemon tests

--- a/packages/configorama/plugins/onepassword/op-cache.test.js
+++ b/packages/configorama/plugins/onepassword/op-cache.test.js
@@ -14,6 +14,9 @@ function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'configorama-op-cache-'))
 }
 
+const LINK_ITEM_ID = 'abcdefghijklmnopqrstuvwxyz'
+const INI_NOTE = 'NPM_TOKEN=npm-secret\n\n[database]\npassword=db-pass\n'
+
 function fakeOp(dir) {
   const bin = path.join(dir, 'fake-op.js')
   const count = path.join(dir, 'count.txt')
@@ -29,15 +32,26 @@ if (process.env.FAKE_OP_FAIL) {
   process.exit(1)
 }
 if (args[0] === 'read') {
-  process.stdout.write(process.env.FAKE_OP_VALUE || 'cached-secret')
+  const ref = args[2]
+  if (ref && ref.endsWith('/notesPlain')) {
+    process.stdout.write(${JSON.stringify(INI_NOTE)})
+  } else {
+    process.stdout.write(process.env.FAKE_OP_VALUE || 'cached-secret')
+  }
   process.exit(0)
 }
 if (args[0] === 'item') {
-  process.stdout.write(JSON.stringify({
-    id: args[2],
-    title: args[2],
-    fields: [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'item-secret' }]
-  }))
+  const id = args[2]
+  const itemFields = {
+    'note-item': [{ id: 'notesPlain', type: 'STRING', purpose: 'NOTES', label: 'notesPlain', value: ${JSON.stringify(INI_NOTE)} }],
+    'multi-section': [
+      { id: 'f1', type: 'CONCEALED', label: 'apikey', section: { id: 's1', label: 'prod' }, value: 'prod-key' },
+      { id: 'f2', type: 'CONCEALED', label: 'apikey', section: { id: 's2', label: 'staging' }, value: 'staging-key' },
+    ],
+    ${JSON.stringify(LINK_ITEM_ID)}: [{ id: 'credential', type: 'CONCEALED', label: 'credential', value: 'link-secret' }],
+  }
+  const fields = itemFields[id] || [{ id: 'password', type: 'CONCEALED', purpose: 'PASSWORD', label: 'password', value: 'item-secret' }]
+  process.stdout.write(JSON.stringify({ id, title: id, fields }))
   process.exit(0)
 }
 process.stderr.write('unknown fake op command')
@@ -45,6 +59,28 @@ process.exit(1)
 `)
   fs.chmodSync(bin, 0o755)
   return { bin, calls: () => Number(fs.readFileSync(count, 'utf8') || '0') }
+}
+
+// op-cache memoizes env-derived config per process; in-process daemon tests
+// must reset it so each test's socket path takes effect.
+const { resetConfigCache } = require('@davidwells/op-cache/src/config')
+
+async function withCacheEnv(env, fn) {
+  const priorSocket = process.env.OP_CACHE_SOCKET_PATH
+  const priorOp = process.env.OP_CACHE_OP_PATH
+  process.env.OP_CACHE_SOCKET_PATH = env.OP_CACHE_SOCKET_PATH
+  process.env.OP_CACHE_OP_PATH = env.OP_CACHE_OP_PATH
+  resetConfigCache()
+  try {
+    return await fn()
+  } finally {
+    if (priorSocket === undefined) delete process.env.OP_CACHE_SOCKET_PATH
+    else process.env.OP_CACHE_SOCKET_PATH = priorSocket
+    if (priorOp === undefined) delete process.env.OP_CACHE_OP_PATH
+    else process.env.OP_CACHE_OP_PATH = priorOp
+    resetConfigCache()
+    stop(env)
+  }
 }
 
 function envFor(dir, fake) {
@@ -108,7 +144,7 @@ test('no cache option preserves existing direct op behavior', async () => {
   assert.is(fake.calls(), 1)
 })
 
-test('item reads do not use op-cache daemon', async () => {
+test('item reads use op-cache across separate resolver runs when configured', async () => {
   const dir = tempDir()
   const fake = fakeOp(dir)
   const env = envFor(dir, fake)
@@ -117,14 +153,20 @@ test('item reads do not use op-cache daemon', async () => {
   process.env.OP_CACHE_SOCKET_PATH = env.OP_CACHE_SOCKET_PATH
   process.env.OP_CACHE_OP_PATH = fake.bin
   try {
-    const source = createOnePasswordResolver({
-      opPath: fake.bin,
-      cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:item-bypass' },
-    })
-    const config = await configorama({ password: '${op(database-prod).password}' }, { variableSources: [source] })
-    assert.is(config.password, 'item-secret')
+    const resolveOnce = () => {
+      const source = createOnePasswordResolver({
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:item-cache' },
+      })
+      return configorama({ password: '${op(database-prod).password}' }, { variableSources: [source] })
+    }
+    const first = await resolveOnce()
+    assert.is(first.password, 'item-secret')
     assert.is(fake.calls(), 1)
-    assert.is(fs.existsSync(env.OP_CACHE_SOCKET_PATH), false)
+    // Fresh resolver = fresh in-process caches; only the daemon can satisfy this
+    const second = await resolveOnce()
+    assert.is(second.password, 'item-secret')
+    assert.is(fake.calls(), 1)
   } finally {
     if (prior === undefined) delete process.env.OP_CACHE_SOCKET_PATH
     else process.env.OP_CACHE_SOCKET_PATH = prior
@@ -155,34 +197,35 @@ test('OP_SERVICE_ACCOUNT_TOKEN bypasses cache unless explicitly allowed', async 
   }
 })
 
-test('cache failure fails closed by default and fallbackToOp degrades when enabled', async () => {
+test('cache failure fails closed by default and fallbackToOp degrades when enabled', () => {
+  // op-cache resolves config once per process, so socket-path changes need
+  // real process boundaries - same reason the cross-process test spawns.
   const dir = tempDir()
   const fake = fakeOp(dir)
   const badSocket = path.join(dir, 'not-a-socket')
   fs.writeFileSync(badSocket, 'x')
-  const priorSocket = process.env.OP_CACHE_SOCKET_PATH
-  process.env.OP_CACHE_SOCKET_PATH = badSocket
-  try {
-    try {
-      await resolveWithCache(fake, { provider: 'op-cache', ttlSeconds: 2, scope: 'session:bad' })
-      assert.unreachable('should fail closed')
-    } catch (err) {
-      assert.match(err.message, /Unsafe op-cache socket|failed to start|socket/)
-    }
-    const written = []
-    const originalWrite = process.stderr.write
-    process.stderr.write = (chunk) => { written.push(String(chunk)); return true }
-    try {
-      const config = await resolveWithCache(fake, { provider: 'op-cache', ttlSeconds: 2, scope: 'session:bad', fallbackToOp: true })
-      assert.is(config.token, 'cached-secret')
-    } finally {
-      process.stderr.write = originalWrite
-    }
-    assert.ok(written.join('').includes('cache bypassed'))
-  } finally {
-    if (priorSocket === undefined) delete process.env.OP_CACHE_SOCKET_PATH
-    else process.env.OP_CACHE_SOCKET_PATH = priorSocket
-  }
+  const env = { ...envFor(dir, fake), OP_CACHE_SOCKET_PATH: badSocket }
+  const codeFor = (cacheJson) => `
+const configorama = require('./src')
+const createOnePasswordResolver = require('./plugins/onepassword')
+configorama(
+  { token: '\${op://vault/item/field}' },
+  { variableSources: [createOnePasswordResolver({
+    opPath: process.env.OP_CACHE_OP_PATH,
+    cache: ${cacheJson}
+  })] }
+).then((config) => process.stdout.write(config.token)).catch((err) => {
+  process.stderr.write(err.message)
+  process.exit(1)
+})
+`
+  const closed = childProcess.spawnSync(process.execPath, ['-e', codeFor('{ provider: "op-cache", ttlSeconds: 2, scope: "session:bad" }')], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+  assert.is(closed.status, 1)
+  assert.match(closed.stderr, /Unsafe op-cache socket|failed to start|socket/)
+  const degraded = childProcess.spawnSync(process.execPath, ['-e', codeFor('{ provider: "op-cache", ttlSeconds: 2, scope: "session:bad", fallbackToOp: true }')], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+  assert.is(degraded.status, 0, degraded.stderr)
+  assert.is(degraded.stdout, 'cached-secret')
+  assert.ok(degraded.stderr.includes('cache bypassed'))
 })
 
 test('missing op-cache package with cache configured gives install hint', () => {
@@ -199,6 +242,289 @@ test('missing op-cache package with cache configured gives install hint', () => 
     assert.throws(() => createOnePasswordResolver({ cache: { provider: 'op-cache' } }), /npm install @davidwells\/op-cache/)
   } finally {
     Module._load = originalLoad
+  }
+})
+
+test('alias to structured note key paths cache final values across fresh resolvers', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  await withCacheEnv(env, async () => {
+    const resolveOnce = () => {
+      const source = createOnePasswordResolver({
+        refs: { npm: 'note-item' },
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:note-keys' },
+      })
+      return configorama(
+        { token: '${op:npm.NPM_TOKEN}', dbPass: '${op:npm.database.password}' },
+        { variableSources: [source] }
+      )
+    }
+    const first = await resolveOnce()
+    assert.is(first.token, 'npm-secret')
+    assert.is(first.dbPass, 'db-pass')
+    assert.is(fake.calls(), 1)
+    const second = await resolveOnce()
+    assert.is(second.token, 'npm-secret')
+    assert.is(second.dbPass, 'db-pass')
+    assert.is(fake.calls(), 1)
+  })
+})
+
+test('direct item ID function syntax caches the final selected field', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  await withCacheEnv(env, async () => {
+    const resolveOnce = () => {
+      const source = createOnePasswordResolver({
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:item-id' },
+      })
+      return configorama({ cred: `\${op(${LINK_ITEM_ID}).credential}` }, { variableSources: [source] })
+    }
+    assert.is((await resolveOnce()).cred, 'link-secret')
+    assert.is((await resolveOnce()).cred, 'link-secret')
+    assert.is(fake.calls(), 1)
+  })
+})
+
+test('private link syntax caches and never exposes the raw URL', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const link = `https://start.1password.com/open/i?a=ACCOUNT&v=vaultid123&i=${LINK_ITEM_ID}&h=my.1password.com`
+  await withCacheEnv(env, async () => {
+    const sources = []
+    const resolveOnce = () => {
+      const source = createOnePasswordResolver({
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:link' },
+      })
+      sources.push(source)
+      return configorama({ cred: `\${op(${link}).credential}` }, { variableSources: [source] })
+    }
+    assert.is((await resolveOnce()).cred, 'link-secret')
+    assert.is((await resolveOnce()).cred, 'link-secret')
+    assert.is(fake.calls(), 1)
+    for (const source of sources) {
+      const serialized = JSON.stringify(source.collectMetadata())
+      assert.not.match(serialized, /start\.1password\.com|ACCOUNT|my\.1password\.com/)
+    }
+  })
+})
+
+test('object refs cache per section', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  await withCacheEnv(env, async () => {
+    const resolveOnce = () => {
+      const source = createOnePasswordResolver({
+        refs: {
+          prodKey: { item: 'multi-section', section: 'prod', field: 'apikey' },
+          stagingKey: { item: 'multi-section', section: 'staging', field: 'apikey' },
+        },
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:sections' },
+      })
+      return configorama(
+        { prod: '${op:prodKey}', staging: '${op:stagingKey}' },
+        { variableSources: [source] }
+      )
+    }
+    const first = await resolveOnce()
+    assert.is(first.prod, 'prod-key')
+    assert.is(first.staging, 'staging-key')
+    assert.is(fake.calls(), 1)
+    const second = await resolveOnce()
+    assert.is(second.prod, 'prod-key')
+    assert.is(second.staging, 'staging-key')
+    assert.is(fake.calls(), 1)
+  })
+})
+
+test('direct op:// with key path caches the final key value', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  await withCacheEnv(env, async () => {
+    const resolveOnce = () => {
+      const source = createOnePasswordResolver({
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:ref-key' },
+      })
+      return configorama({ token: '${op(op://vault/item/notesPlain).NPM_TOKEN}' }, { variableSources: [source] })
+    }
+    assert.is((await resolveOnce()).token, 'npm-secret')
+    assert.is((await resolveOnce()).token, 'npm-secret')
+    assert.is(fake.calls(), 1)
+  })
+})
+
+test('opReferences metadata is identical between miss and hit runs', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  await withCacheEnv(env, async () => {
+    const resolveOnce = async () => {
+      const source = createOnePasswordResolver({
+        refs: { db: 'database-prod' },
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:meta' },
+      })
+      await configorama({ password: '${op:db}' }, { variableSources: [source] })
+      return source.collectMetadata()
+    }
+    const missRun = await resolveOnce()
+    assert.is(fake.calls(), 1)
+    const hitRun = await resolveOnce()
+    assert.is(fake.calls(), 1)
+    // Inferred field name survives the cache hit via the envelope
+    assert.is(missRun[0].field, 'password')
+    assert.equal(hitRun, missRun)
+  })
+})
+
+test('corrupted cache entries are recomputed and overwritten', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const opCacheApi = require('@davidwells/op-cache')
+  const { buildCacheRef } = require('./cache-ref')
+  await withCacheEnv(env, async () => {
+    const reference = { kind: 'item', item: 'database-prod', vault: undefined, section: undefined, field: undefined }
+    const cacheRef = buildCacheRef(reference, 'password')
+    // Seed a non-envelope entry under the exact key the resolver will use
+    await opCacheApi.getOrSet(cacheRef, async () => 'raw-not-an-envelope', {
+      opPath: fake.bin,
+      scope: 'session:corrupt',
+      ttlSeconds: 2,
+    })
+    const resolveOnce = () => {
+      const source = createOnePasswordResolver({
+        opPath: fake.bin,
+        cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:corrupt' },
+      })
+      return configorama({ password: '${op(database-prod).password}' }, { variableSources: [source] })
+    }
+    // The rejection warning is expected output - capture and assert it
+    const written = []
+    const originalWrite = process.stderr.write
+    process.stderr.write = (chunk) => { written.push(String(chunk)); return true }
+    let first
+    try {
+      first = await resolveOnce()
+    } finally {
+      process.stderr.write = originalWrite
+    }
+    assert.is(first.password, 'item-secret')
+    assert.is(fake.calls(), 1)
+    assert.ok(written.join('').includes('failed validation'))
+    // Overwrite proven: the next fresh resolver hits the repaired entry
+    const second = await resolveOnce()
+    assert.is(second.password, 'item-secret')
+    assert.is(fake.calls(), 1)
+  })
+})
+
+test('OP_CACHE_DISABLED=1 bypasses item syntax caching entirely', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const priorDisabled = process.env.OP_CACHE_DISABLED
+  process.env.OP_CACHE_DISABLED = '1'
+  try {
+    await withCacheEnv(env, async () => {
+      const resolveOnce = () => {
+        const source = createOnePasswordResolver({
+          opPath: fake.bin,
+          cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:disabled' },
+        })
+        return configorama({ password: '${op(database-prod).password}' }, { variableSources: [source] })
+      }
+      assert.is((await resolveOnce()).password, 'item-secret')
+      assert.is((await resolveOnce()).password, 'item-secret')
+      assert.is(fake.calls(), 2)
+      assert.is(fs.existsSync(env.OP_CACHE_SOCKET_PATH), false)
+    })
+  } finally {
+    if (priorDisabled === undefined) delete process.env.OP_CACHE_DISABLED
+    else process.env.OP_CACHE_DISABLED = priorDisabled
+  }
+})
+
+test('service account token bypasses item syntax caching unless allowed', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const priorToken = process.env.OP_SERVICE_ACCOUNT_TOKEN
+  process.env.OP_SERVICE_ACCOUNT_TOKEN = 'token-value'
+  try {
+    await withCacheEnv(env, async () => {
+      const resolveOnce = () => {
+        const source = createOnePasswordResolver({
+          opPath: fake.bin,
+          cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:token-item' },
+        })
+        return configorama({ password: '${op(database-prod).password}' }, { variableSources: [source] })
+      }
+      assert.is((await resolveOnce()).password, 'item-secret')
+      assert.is((await resolveOnce()).password, 'item-secret')
+      assert.is(fake.calls(), 2)
+      assert.is(fs.existsSync(env.OP_CACHE_SOCKET_PATH), false)
+    })
+  } finally {
+    if (priorToken === undefined) delete process.env.OP_SERVICE_ACCOUNT_TOKEN
+    else process.env.OP_SERVICE_ACCOUNT_TOKEN = priorToken
+  }
+})
+
+test('duplicate refs in one config share one op call through the promise cache', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  await withCacheEnv(env, async () => {
+    const source = createOnePasswordResolver({
+      opPath: fake.bin,
+      cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:dupes' },
+    })
+    const config = await configorama(
+      { a: '${op(database-prod).password}', b: '${op(database-prod).password}' },
+      { variableSources: [source] }
+    )
+    assert.is(config.a, 'item-secret')
+    assert.is(config.b, 'item-secret')
+    assert.is(fake.calls(), 1)
+  })
+})
+
+test('sync worker path caches item reads across separate processes', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = envFor(dir, fake)
+  const code = `
+const configorama = require('./src')
+const createOnePasswordResolver = require('./plugins/onepassword')
+const source = createOnePasswordResolver({
+  opPath: process.env.OP_CACHE_OP_PATH,
+  cache: { provider: 'op-cache', ttlSeconds: 2, scope: 'session:sync-worker' }
+})
+const config = configorama.sync({ password: '\${op(database-prod).password}' }, { variableSources: [source] })
+process.stdout.write(config.password)
+`
+  try {
+    const first = childProcess.spawnSync(process.execPath, ['-e', code], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+    assert.is(first.status, 0, first.stderr)
+    assert.is(first.stdout, 'item-secret')
+    assert.is(fake.calls(), 1)
+    const second = childProcess.spawnSync(process.execPath, ['-e', code], { cwd: __dirname + '/../..', env, encoding: 'utf8' })
+    assert.is(second.status, 0, second.stderr)
+    assert.is(second.stdout, 'item-secret')
+    assert.is(fake.calls(), 1)
+  } finally {
+    stop(env)
   }
 })
 

--- a/packages/configx/README.md
+++ b/packages/configx/README.md
@@ -183,6 +183,8 @@ configx .env -- ./my-app
 
 `${op://vault/item/field}` is the 1Password secret-reference URI — it points directly at a single field. For a key path into a structured note (`${op:alias.KEY}`), use the alias form via a `configx.config.js`. Both need the 1Password resolver registered.
 
+To reduce repeated 1Password prompts across fresh agent commands, opt into `@davidwells/op-cache` in the Configorama 1Password resolver. `configx` remains only the runner; cache semantics live in the resolver/package docs.
+
 ## Behavior
 
 - **Top-level scalar keys only.** `string`, `number`, and `boolean` values become env vars (numbers/booleans stringified). `null`/`undefined` are skipped. Nested objects/arrays are an error — env vars are flat.

--- a/packages/op-cache/CHANGELOG.md
+++ b/packages/op-cache/CHANGELOG.md
@@ -4,3 +4,5 @@
 
 - Initial public package for a per-user in-memory 1Password `op://` read cache.
 - Adds `op-cache read`, lifecycle diagnostics, JSON status/stats/doctor output, scoped TTL cache entries, daemon idle exit, and Configorama 1Password resolver integration support.
+- Adds `getOrSet(cacheRef, producer, opts)` advanced integration API: caller-supplied miss producers, `validateCached` hook with recompute-and-overwrite, once-per-process clamp and validation warnings, and the same bypass/fallback ladder as `read`. Powers all-syntax final-value caching in the Configorama 1Password resolver (aliases, item names/IDs, private links, sections, structured note key paths).
+- Daemon rejects over-long Unix socket paths with an actionable error and removes its signal listeners on close.

--- a/packages/op-cache/CHANGELOG.md
+++ b/packages/op-cache/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 0.1.0
+
+- Initial public package for a per-user in-memory 1Password `op://` read cache.
+- Adds `op-cache read`, lifecycle diagnostics, JSON status/stats/doctor output, scoped TTL cache entries, daemon idle exit, and Configorama 1Password resolver integration support.

--- a/packages/op-cache/LICENSE
+++ b/packages/op-cache/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) David Wells
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/op-cache/README.md
+++ b/packages/op-cache/README.md
@@ -84,7 +84,45 @@ module.exports = {
 }
 ```
 
-The resolver caches only direct `op://` reads in v1. Item JSON reads still use `op item get --reveal`.
+The resolver caches every supported `${op...}` syntax: direct `op://` reads use `op-cache read` keys, and item/alias/private-link/key-path syntaxes cache their final resolved values through `getOrSet`.
+
+## getOrSet (Advanced Integration API)
+
+`getOrSet` is get-or-compute for integrations whose miss producer is their own
+logic rather than `op read`. It is API-only — there is no CLI command, because
+producers are functions.
+
+```js
+const { getOrSet } = require('@davidwells/op-cache')
+
+const value = await getOrSet('my-tool://v1/<hash>', async () => {
+  return computeTheValueSomehow() // must return a string
+}, {
+  account,
+  configDir,
+  opPath,
+  ttlSeconds: 300,
+  scope: 'user',
+  fallbackToOp: false,
+  validateCached: (cached) => looksValid(cached)
+})
+```
+
+Semantics:
+
+- any non-empty reference string is accepted; `account`/`configDir`/`opPath`
+  are applied as cache key dimensions exactly as for `read`
+- `OP_CACHE_DISABLED=1` and win32 run the producer directly, never touching
+  the daemon
+- on a hit, `validateCached(value)` runs first when provided; returning
+  `false` or throwing treats the entry as unusable — the producer recomputes
+  and overwrites it, with a one-line stderr note at most once per process
+- the producer must return a string; anything else throws and stores nothing
+- producer failures surface unchanged and are never cached
+- `fallbackToOp: false` (default) fails closed on daemon failure before the
+  producer runs; `true` means "on daemon failure, do the work directly" —
+  the fallback runs the producer, with the same stderr warning style as `read`
+- TTL clamping by the daemon warns at most once per process
 
 ## Daemon Lifecycle
 

--- a/packages/op-cache/README.md
+++ b/packages/op-cache/README.md
@@ -1,0 +1,119 @@
+# @davidwells/op-cache
+
+`op-cache` is a per-user, in-memory cache daemon for 1Password `op://` secret references. It is designed for fresh-process agent workflows where the same command runs repeatedly and each `op read` would otherwise trigger another 1Password prompt.
+
+```bash
+op-cache read op://Private/MyItem/password
+op-cache status --json
+op-cache stats
+op-cache clear
+op-cache doctor --json
+op-cache stop
+```
+
+Secrets are never written to disk. The daemon stores values in memory behind a `0600` Unix socket owned by the current user, applies a default 5 minute TTL, and periodically sweeps expired entries.
+
+## Install
+
+```bash
+npm install -g @davidwells/op-cache
+```
+
+## Config
+
+Config is optional JSON at `~/.config/op-cache/config.json`:
+
+```json
+{
+  "ttl_seconds": 300,
+  "max_ttl_seconds": 86400,
+  "max_entries": 1000,
+  "op_path": "op",
+  "op_timeout_seconds": 30,
+  "default_scope": "user",
+  "idle_exit_seconds": 1800
+}
+```
+
+Precedence is CLI flags, `OP_CACHE_*` environment variables, config file, then defaults.
+
+Useful environment variables:
+
+```bash
+OP_CACHE_SOCKET_PATH=/tmp/op-cache-dev.sock
+OP_CACHE_TTL_SECONDS=300
+OP_CACHE_MAX_TTL_SECONDS=3600
+OP_CACHE_SCOPE="session:claude-thread-abc"
+OP_CACHE_DISABLED=1
+```
+
+## TTL And Scope
+
+```bash
+op-cache read op://Private/MyItem/password --ttl 5m
+OP_CACHE_SCOPE="session:claude-thread-abc" op-cache read op://Private/MyItem/password
+```
+
+Supported TTL formats are `30s`, `5m`, `1h`, and bare seconds like `300`.
+
+Scopes partition cache entries:
+
+- `user` shares entries for the same user/account/config/op path.
+- `session` uses `OP_CACHE_SESSION` first, then `OP_CACHE_SCOPE`; bare `session` errors if neither is set.
+- `session:<name>` uses the inline session name.
+- `pid` and `ppid` include process ownership metadata.
+- Any other string is a custom scope.
+
+## Configorama
+
+`configx` stays a runner. Cache integration belongs in the Configorama 1Password resolver:
+
+```js
+const createOnePasswordResolver = require('configorama/plugins/onepassword')
+
+module.exports = {
+  variableSources: [
+    createOnePasswordResolver({
+      cache: {
+        provider: 'op-cache',
+        ttlSeconds: 300,
+        scope: process.env.OP_CACHE_SCOPE || 'user'
+      }
+    })
+  ]
+}
+```
+
+The resolver caches only direct `op://` reads in v1. Item JSON reads still use `op item get --reveal`.
+
+## Daemon Lifecycle
+
+Only `op-cache read` starts the daemon. Diagnostic commands such as `status`, `stats`, `clear`, `stop`, and `doctor` do not spawn a daemon just to report an empty cache.
+
+The daemon exits after `idle_exit_seconds` only when the cache is empty. To reload config, run:
+
+```bash
+op-cache stop
+```
+
+The next read starts a fresh daemon with the current config.
+
+`OP_CACHE_DISABLED=1` bypasses the daemon entirely and executes `op read` directly.
+
+## Agent Ergonomics
+
+`status`, `stats`, and `doctor` support `--json` for machine parsing:
+
+```bash
+op-cache status --json
+op-cache stats --json
+op-cache doctor --json
+```
+
+Secret values only appear on stdout for `op-cache read`. Diagnostics and warnings go to stderr unless the command explicitly emits JSON.
+
+## Security Model
+
+This is a same-user convenience cache, not a hard isolation boundary. Secret values are held in daemon memory and returned over a user-owned `0600` Unix socket. Values are never logged or persisted. TTL defaults to 5 minutes, `max_ttl_seconds` clamps unexpectedly long requests, and periodic sweeping bounds how long expired values remain in memory. Use `op-cache clear`, `op-cache stop`, or `OP_CACHE_DISABLED=1` when you want to bypass the cache.
+
+The Rust prototype in `_misc/op-cache` remains as a reference. Remove old `op-cache` binaries from `PATH` if you install this package; separate implementations can use separate sockets and appear as two daemons.

--- a/packages/op-cache/package.json
+++ b/packages/op-cache/package.json
@@ -8,7 +8,7 @@
   },
   "type": "commonjs",
   "scripts": {
-    "test": "node test/unit.test.js && node test/cli.test.js && node test/integration.test.js"
+    "test": "node test/unit.test.js && node test/cli.test.js && node test/integration.test.js && node test/get-or-set.test.js"
   },
   "files": [
     "src",

--- a/packages/op-cache/package.json
+++ b/packages/op-cache/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "@davidwells/op-cache",
+  "version": "0.1.0",
+  "description": "Per-user in-memory cache daemon for 1Password op:// reads",
+  "main": "src/api.js",
+  "bin": {
+    "op-cache": "src/cli.js"
+  },
+  "type": "commonjs",
+  "scripts": {
+    "test": "node test/unit.test.js && node test/cli.test.js && node test/integration.test.js"
+  },
+  "files": [
+    "src",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "package.json"
+  ],
+  "keywords": [
+    "1password",
+    "op",
+    "secrets",
+    "cache",
+    "configorama"
+  ],
+  "author": "David Wells",
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/DavidWells/configorama/tree/master/packages/op-cache#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/DavidWells/configorama.git",
+    "directory": "packages/op-cache"
+  },
+  "bugs": {
+    "url": "https://github.com/DavidWells/configorama/issues"
+  },
+  "engines": {
+    "node": ">=22"
+  },
+  "devDependencies": {
+    "uvu": "^0.5.6"
+  }
+}

--- a/packages/op-cache/src/api.js
+++ b/packages/op-cache/src/api.js
@@ -1,0 +1,126 @@
+/* Programmatic API for op-cache callers.
+   Configorama's 1Password resolver consumes these module-level functions. */
+const { resolveConfig } = require('./config')
+const { resolveScope } = require('./scope')
+const { cacheKey, effectiveAccount, shortHash } = require('./key')
+const { readOp } = require('./op')
+const { ensureDaemon, request, ping } = require('./client')
+const { startDaemon } = require('./daemon')
+
+/**
+ * @param {string} ref - op:// reference
+ * @param {object} [opts] - Read options
+ * @returns {Promise<string>}
+ */
+async function read(ref, opts = {}) {
+  if (!ref || !ref.startsWith('op://')) throw new Error(`Invalid 1Password reference: ${ref}`)
+  const env = opts.env || process.env
+  const { config } = resolveConfig(optionFlags(opts), { env })
+  const account = effectiveAccount(opts.account, env)
+  if (env.OP_CACHE_DISABLED === '1' || opts.platform === 'win32' || process.platform === 'win32') {
+    return readOp(ref, config, { account, configDir: opts.configDir })
+  }
+  const scopeInfo = resolveScope(opts.scope || config.default_scope, { env })
+  const key = cacheKey({ scope: scopeInfo.scope, account, configDir: opts.configDir, opPath: config.op_path, reference: ref })
+  const fallbackToOp = opts.fallbackToOp === true
+  try {
+    await ensureDaemon(config, { stderr: opts.stderr })
+    const got = await request(config, { type: 'get', key, scope: scopeInfo.scope })
+    if (got.type === 'hit') return got.value
+    const value = await readOp(ref, config, { account, configDir: opts.configDir })
+    const stored = await request(config, {
+      type: 'set',
+      key,
+      value,
+      scope: scopeInfo.scope,
+      ttlSeconds: config.ttl_seconds,
+      ownerPid: scopeInfo.ownerPid,
+      refHash: shortHash(ref),
+      accountHash: shortHash(account),
+    })
+    if (stored.clamped && opts.stderr) {
+      opts.stderr.write(`op-cache: ttl clamped to ${stored.ttlSeconds}s by daemon max_ttl_seconds\n`)
+    }
+    return value
+  } catch (err) {
+    if (!fallbackToOp) throw err
+    if (opts.stderr) opts.stderr.write(`op-cache: cache bypassed (${err.message}); reading directly\n`)
+    return readOp(ref, config, { account, configDir: opts.configDir })
+  }
+}
+
+/**
+ * @param {object} [opts] - Options
+ * @returns {Promise<object>}
+ */
+async function status(opts = {}) {
+  const { config } = resolveConfig(optionFlags(opts), { env: opts.env || process.env })
+  if (opts.platform === 'win32' || process.platform === 'win32') return { running: false, platform: 'win32', available: false }
+  try {
+    const pong = await ping(config)
+    return { running: true, available: true, socketPath: config.socket_path, daemon: pong }
+  } catch (err) {
+    return { running: false, available: true, socketPath: config.socket_path, error: err.message }
+  }
+}
+
+/**
+ * @param {object} [opts] - Options
+ * @returns {Promise<object>}
+ */
+async function stats(opts = {}) {
+  if (opts.platform === 'win32' || process.platform === 'win32') return { type: 'stats', entries: 0, hits: 0, misses: 0, available: false, platform: 'win32' }
+  const { config } = resolveConfig(optionFlags(opts), { env: opts.env || process.env })
+  const scopeInfo = opts.scope ? resolveScope(opts.scope, { env: opts.env || process.env }) : undefined
+  return request(config, { type: 'stats', scope: scopeInfo && scopeInfo.scope })
+}
+
+/**
+ * @param {object} [opts] - Options
+ * @returns {Promise<object>}
+ */
+async function clear(opts = {}) {
+  if (opts.platform === 'win32' || process.platform === 'win32') return { type: 'cleared', removed: 0, available: false, platform: 'win32' }
+  const { config } = resolveConfig(optionFlags(opts), { env: opts.env || process.env })
+  const scopeInfo = opts.scope ? resolveScope(opts.scope, { env: opts.env || process.env }) : undefined
+  return request(config, { type: 'clear', scope: scopeInfo && scopeInfo.scope })
+}
+
+/**
+ * @param {object} [opts] - Options
+ * @returns {Promise<object>}
+ */
+async function stop(opts = {}) {
+  if (opts.platform === 'win32' || process.platform === 'win32') return { type: 'stopped', available: false, platform: 'win32' }
+  const { config } = resolveConfig(optionFlags(opts), { env: opts.env || process.env })
+  return request(config, { type: 'shutdown' })
+}
+
+/**
+ * @param {object} [opts] - Options
+ * @returns {Promise<object>}
+ */
+async function start(opts = {}) {
+  const { config } = resolveConfig(optionFlags(opts), { env: opts.env || process.env })
+  return startDaemon(config, opts)
+}
+
+/**
+ * @param {object} opts - Input opts
+ * @returns {object}
+ */
+function optionFlags(opts) {
+  return {
+    socketPath: opts.socketPath,
+    ttlSeconds: opts.ttlSeconds,
+    maxTtlSeconds: opts.maxTtlSeconds,
+    maxEntries: opts.maxEntries,
+    opPath: opts.opPath,
+    opTimeoutSeconds: opts.opTimeoutSeconds,
+    idleExitSeconds: opts.idleExitSeconds,
+    scope: opts.scope,
+    configPath: opts.configPath,
+  }
+}
+
+module.exports = { read, status, stats, clear, stop, start, ensureDaemon }

--- a/packages/op-cache/src/api.js
+++ b/packages/op-cache/src/api.js
@@ -49,6 +49,114 @@ async function read(ref, opts = {}) {
   }
 }
 
+// One warning per kind per stream. Production callers pass process.stderr,
+// so this is once-per-process; test streams each warn once.
+const warnedStreams = new WeakMap()
+
+/**
+ * @param {NodeJS.WritableStream|undefined} stderr - Warning stream
+ * @param {string} kind - Warning category
+ * @param {string} message - Warning text
+ */
+function warnOnce(stderr, kind, message) {
+  if (!stderr) return
+  let kinds = warnedStreams.get(stderr)
+  if (!kinds) {
+    kinds = new Set()
+    warnedStreams.set(stderr, kinds)
+  }
+  if (kinds.has(kind)) return
+  kinds.add(kind)
+  stderr.write(message)
+}
+
+/**
+ * @param {Function} producer - Async producer returning the value string
+ * @returns {Promise<string>}
+ */
+async function produce(producer) {
+  const value = await producer()
+  if (typeof value !== 'string') throw new Error('op-cache getOrSet producer must return a string.')
+  return value
+}
+
+/**
+ * @param {Function} validate - Caller validator
+ * @param {string} value - Cached value
+ * @returns {boolean}
+ */
+function validateQuietly(validate, value) {
+  try {
+    return validate(value) !== false
+  } catch (err) {
+    return false
+  }
+}
+
+/**
+ * Get-or-compute: cache lookup where the miss producer is caller logic, not
+ * `op read`. Advanced integration API for resolvers caching computed values.
+ * fallbackToOp here means "on daemon failure, do the work directly" — the
+ * fallback runs the producer; the name matches read for option continuity.
+ * @param {string} cacheRef - Cache reference; any non-empty string
+ * @param {Function} producer - Async producer invoked on miss; must return a string
+ * @param {object} [opts] - Options ({ account, configDir, opPath, ttlSeconds, scope, fallbackToOp, validateCached, stderr, env })
+ * @returns {Promise<string>}
+ */
+async function getOrSet(cacheRef, producer, opts = {}) {
+  if (!cacheRef || typeof cacheRef !== 'string') throw new Error('op-cache getOrSet requires a non-empty cache reference string.')
+  if (typeof producer !== 'function') throw new Error('op-cache getOrSet requires a producer function.')
+  const env = opts.env || process.env
+  const { config } = resolveConfig(optionFlags(opts), { env })
+  const account = effectiveAccount(opts.account, env)
+  if (env.OP_CACHE_DISABLED === '1' || opts.platform === 'win32' || process.platform === 'win32') {
+    return produce(producer)
+  }
+  const scopeInfo = resolveScope(opts.scope || config.default_scope, { env })
+  const key = cacheKey({ scope: scopeInfo.scope, account, configDir: opts.configDir, opPath: config.op_path, reference: cacheRef })
+  const fallbackToOp = opts.fallbackToOp === true
+  let daemonBroken = false
+  let got
+  try {
+    await ensureDaemon(config, { stderr: opts.stderr })
+    got = await request(config, { type: 'get', key, scope: scopeInfo.scope })
+  } catch (err) {
+    if (!fallbackToOp) throw err
+    if (opts.stderr) opts.stderr.write(`op-cache: cache bypassed (${err.message}); resolving directly\n`)
+    daemonBroken = true
+  }
+  if (!daemonBroken && got.type === 'hit') {
+    if (!opts.validateCached || validateQuietly(opts.validateCached, got.value)) {
+      return got.value
+    }
+    warnOnce(opts.stderr, 'validate-reject', 'op-cache: cached entry failed validation; recomputing and overwriting\n')
+  }
+  // Producer errors propagate untouched and the producer never runs twice:
+  // only daemon get/set failures participate in the fallback path above/below.
+  const value = await produce(producer)
+  if (!daemonBroken) {
+    try {
+      const stored = await request(config, {
+        type: 'set',
+        key,
+        value,
+        scope: scopeInfo.scope,
+        ttlSeconds: config.ttl_seconds,
+        ownerPid: scopeInfo.ownerPid,
+        refHash: shortHash(cacheRef),
+        accountHash: shortHash(account),
+      })
+      if (stored.clamped) {
+        warnOnce(opts.stderr, 'ttl-clamp', `op-cache: ttl clamped to ${stored.ttlSeconds}s by daemon max_ttl_seconds\n`)
+      }
+    } catch (err) {
+      if (!fallbackToOp) throw err
+      if (opts.stderr) opts.stderr.write(`op-cache: cache bypassed (${err.message}); value not stored\n`)
+    }
+  }
+  return value
+}
+
 /**
  * @param {object} [opts] - Options
  * @returns {Promise<object>}
@@ -123,4 +231,4 @@ function optionFlags(opts) {
   }
 }
 
-module.exports = { read, status, stats, clear, stop, start, ensureDaemon }
+module.exports = { read, getOrSet, status, stats, clear, stop, start, ensureDaemon }

--- a/packages/op-cache/src/cache.js
+++ b/packages/op-cache/src/cache.js
@@ -1,0 +1,140 @@
+/* In-memory TTL/LRU cache used by the daemon.
+   Supports scoped clearing and entry counts without exposing raw refs. */
+
+class SecretCache {
+  /**
+   * @param {object} options - Cache options
+   */
+  constructor(options = {}) {
+    this.maxEntries = options.maxEntries || 1000
+    this.now = options.now || (() => Date.now())
+    this.map = new Map()
+    this.hits = 0
+    this.misses = 0
+  }
+
+  /**
+   * @param {string} key - Opaque cache key
+   * @returns {string|undefined}
+   */
+  get(key) {
+    const entry = this.map.get(key)
+    if (!entry) {
+      this.misses += 1
+      return undefined
+    }
+    if (entry.expiresAt <= this.now()) {
+      this.map.delete(key)
+      this.misses += 1
+      return undefined
+    }
+    if (entry.ownerPid && !isPidAlive(entry.ownerPid)) {
+      this.map.delete(key)
+      this.misses += 1
+      return undefined
+    }
+    entry.lastAccessedAt = this.now()
+    this.map.delete(key)
+    this.map.set(key, entry)
+    this.hits += 1
+    return entry.value
+  }
+
+  /**
+   * @param {string} key - Opaque cache key
+   * @param {string} value - Secret value
+   * @param {object} meta - Entry metadata
+   */
+  set(key, value, meta) {
+    const now = this.now()
+    this.map.set(key, {
+      value,
+      expiresAt: now + meta.ttlSeconds * 1000,
+      createdAt: now,
+      lastAccessedAt: now,
+      scope: meta.scope,
+      ownerPid: meta.ownerPid,
+      refHash: meta.refHash,
+      accountHash: meta.accountHash,
+    })
+    while (this.map.size > this.maxEntries) {
+      const oldest = this.map.keys().next().value
+      this.map.delete(oldest)
+    }
+  }
+
+  sweep() {
+    const now = this.now()
+    let removed = 0
+    for (const [key, entry] of this.map.entries()) {
+      if (entry.expiresAt <= now || (entry.ownerPid && !isPidAlive(entry.ownerPid))) {
+        this.map.delete(key)
+        removed += 1
+      }
+    }
+    return removed
+  }
+
+  clear(scope) {
+    if (!scope) {
+      const removed = this.map.size
+      this.map.clear()
+      this.hits = 0
+      this.misses = 0
+      return removed
+    }
+    return this.clearScope(scope)
+  }
+
+  clearScope(scope) {
+    let removed = 0
+    for (const [key, entry] of this.map.entries()) {
+      if (entry.scope === scope) {
+        this.map.delete(key)
+        removed += 1
+      }
+    }
+    return removed
+  }
+
+  countByScope(scope) {
+    this.sweep()
+    let n = 0
+    for (const entry of this.map.values()) {
+      if (entry.scope === scope) n += 1
+    }
+    return n
+  }
+
+  isEmpty() {
+    this.sweep()
+    return this.map.size === 0
+  }
+
+  stats(scope) {
+    this.sweep()
+    if (scope) return { scope, entries: this.countByScope(scope) }
+    const total = this.hits + this.misses
+    return {
+      entries: this.map.size,
+      hits: this.hits,
+      misses: this.misses,
+      hitRate: total ? this.hits / total : 0,
+    }
+  }
+}
+
+/**
+ * @param {number} pid - Process ID
+ * @returns {boolean}
+ */
+function isPidAlive(pid) {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (err) {
+    return err && err.code === 'EPERM'
+  }
+}
+
+module.exports = { SecretCache, isPidAlive }

--- a/packages/op-cache/src/cli.js
+++ b/packages/op-cache/src/cli.js
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/* CLI for @davidwells/op-cache.
+   Dispatches cache reads, lifecycle diagnostics, and daemon mode. */
+const fs = require('fs')
+const { read, status, stats, clear, stop, start } = require('./api')
+const { resolveConfig, configPath } = require('./config')
+const { readOp } = require('./op')
+const pkg = require('../package.json')
+
+/**
+ * @param {string[]} argv - Arguments
+ * @returns {object}
+ */
+function parse(argv) {
+  const out = { _: [] }
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (!arg.startsWith('--')) {
+      out._.push(arg)
+      continue
+    }
+    const key = arg.slice(2)
+    if (['json', 'help', 'version'].includes(key)) out[key] = true
+    else out[key] = argv[++i]
+  }
+  return out
+}
+
+function usage() {
+  return `op-cache ${pkg.version}
+
+Usage:
+  op-cache read <op://ref> [--account <account>] [--ttl <duration>] [--scope <scope>]
+  op-cache status [--json]
+  op-cache stats [--scope <scope>] [--json]
+  op-cache clear [--scope <scope>]
+  op-cache stop
+  op-cache doctor [--json]
+  op-cache config-path
+`
+}
+
+async function main(argv = process.argv.slice(2), io = process) {
+  const args = parse(argv)
+  const cmd = args._[0]
+  const platform = io.platform || process.platform
+  if (args.help || !cmd) return writeOut(io, usage())
+  if (args.version) return writeOut(io, `${pkg.version}\n`)
+  const opts = {
+    account: args.account,
+    ttlSeconds: args.ttl,
+    scope: args.scope,
+    socketPath: args.socket,
+    opPath: args['op-path'],
+    opTimeoutSeconds: args['op-timeout'],
+    stderr: io.stderr,
+    platform,
+    fallbackToOp: true,
+  }
+
+  if (cmd === 'daemon') {
+    await start({})
+    return new Promise(() => {})
+  }
+  if (cmd === 'daemon-foreground') {
+    await start({ foreground: true })
+    return new Promise(() => {})
+  }
+  if (platform === 'win32' && cmd !== 'read') {
+    const unavailable = { running: false, available: false, platform: 'win32' }
+    if (args.json) writeOut(io, `${JSON.stringify(unavailable)}\n`)
+    else writeOut(io, 'op-cache: caching unavailable on win32\n')
+    return
+  }
+  if (cmd === 'read') {
+    const ref = args._[1]
+    if (!ref) return fail(io, 'missing op:// reference', 2)
+    const value = platform === 'win32'
+      ? await readOp(ref, resolveConfig({}, {}).config, { account: args.account })
+      : await read(ref, opts)
+    writeOut(io, `${value}\n`)
+    return
+  }
+  if (cmd === 'status') {
+    const result = await status(opts)
+    if (args.json) writeOut(io, `${JSON.stringify(result)}\n`)
+    else writeOut(io, result.running ? `daemon running (${result.daemon.version})\n` : 'daemon not running\n')
+    return
+  }
+  if (cmd === 'stats') {
+    try {
+      const result = await stats(opts)
+      if (args.json) writeOut(io, `${JSON.stringify(result)}\n`)
+      else writeOut(io, `entries: ${result.entries}\nhits: ${result.hits || 0}\nmisses: ${result.misses || 0}\n`)
+    } catch (err) {
+      if (args.json) writeOut(io, `${JSON.stringify({ running: false, entries: 0, hits: 0, misses: 0 })}\n`)
+      else writeOut(io, 'daemon not running\n')
+    }
+    return
+  }
+  if (cmd === 'clear') {
+    try {
+      const result = await clear(opts)
+      writeOut(io, `removed: ${result.removed}\n`)
+    } catch (err) {
+      writeOut(io, 'daemon not running\n')
+    }
+    return
+  }
+  if (cmd === 'stop') {
+    try {
+      await stop(opts)
+      writeOut(io, 'daemon stopped\n')
+    } catch (err) {
+      writeOut(io, 'daemon not running\n')
+    }
+    return
+  }
+  if (cmd === 'config-path') {
+    const p = configPath(process.env)
+    writeOut(io, `${p}\n`)
+    if (!fs.existsSync(p)) io.stderr.write('op-cache: config file does not exist\n')
+    return
+  }
+  if (cmd === 'doctor') {
+    const result = await doctor(opts)
+    if (args.json) writeOut(io, `${JSON.stringify(result)}\n`)
+    else writeOut(io, formatDoctor(result))
+    return
+  }
+  return fail(io, `unknown command: ${cmd}\n${usage()}`, 2)
+}
+
+async function doctor(opts) {
+  const resolved = resolveConfig({}, {})
+  const st = await status(opts)
+  return {
+    node: process.version,
+    packageVersion: pkg.version,
+    opPath: resolved.config.op_path,
+    socketPath: resolved.config.socket_path,
+    configPath: resolved.path,
+    configExists: resolved.exists,
+    daemon: st,
+    serviceAccountTokenSet: Boolean(process.env.OP_SERVICE_ACCOUNT_TOKEN),
+    platform: opts.platform || process.platform,
+    cacheAvailable: (opts.platform || process.platform) !== 'win32',
+  }
+}
+
+function formatDoctor(result) {
+  return [
+    `node: ${result.node}`,
+    `op-cache: ${result.packageVersion}`,
+    `op: ${result.opPath}`,
+    `socket: ${result.socketPath}`,
+    `config: ${result.configPath} (${result.configExists ? 'exists' : 'missing'})`,
+    `daemon: ${result.daemon.running ? 'running' : 'not running'}`,
+    `service account token: ${result.serviceAccountTokenSet ? 'set' : 'unset'}`,
+    `platform: ${result.platform}`,
+    '',
+  ].join('\n')
+}
+
+function writeOut(io, text) {
+  io.stdout.write(text)
+}
+
+function fail(io, message, code) {
+  io.stderr.write(`op-cache: ${message}\n`)
+  process.exitCode = code
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    process.stderr.write(`op-cache: ${err.message}\n`)
+    process.exit(1)
+  })
+}
+
+module.exports = { main, parse, usage, doctor }

--- a/packages/op-cache/src/client.js
+++ b/packages/op-cache/src/client.js
@@ -1,0 +1,132 @@
+/* Client-side daemon communication and lifecycle management.
+   Only read paths auto-start the daemon; diagnostics never spawn. */
+const fs = require('fs')
+const net = require('net')
+const { spawn } = require('child_process')
+const { encode, decode } = require('./protocol')
+const { DaemonUnavailableError, ProtocolError } = require('./errors')
+const pkg = require('../package.json')
+
+/**
+ * @param {object} config - Config
+ * @returns {Promise<object>}
+ */
+function ping(config) {
+  return request(config, { type: 'ping' })
+}
+
+/**
+ * @param {object} config - Config
+ * @param {object} message - Request message
+ * @returns {Promise<object>}
+ */
+function request(config, message) {
+  return new Promise((resolve, reject) => {
+    try {
+      assertSafeSocket(config.socket_path)
+    } catch (err) {
+      return reject(err)
+    }
+    const socket = net.createConnection(config.socket_path)
+    let buffer = ''
+    socket.setTimeout(2000)
+    socket.on('connect', () => socket.write(encode(message)))
+    socket.on('data', (chunk) => {
+      buffer += chunk.toString('utf8')
+      const index = buffer.indexOf('\n')
+      if (index !== -1) socket.end()
+    })
+    socket.on('timeout', () => {
+      socket.destroy()
+      reject(new DaemonUnavailableError('Timed out waiting for op-cache daemon.'))
+    })
+    socket.on('error', (err) => reject(new DaemonUnavailableError(`Could not connect to op-cache daemon: ${err.message}`)))
+    socket.on('close', () => {
+      if (!buffer) return
+      try {
+        const response = decode(buffer.split('\n')[0])
+        if (response.type === 'error') reject(new ProtocolError(response.message))
+        else resolve(response)
+      } catch (err) {
+        reject(err)
+      }
+    })
+  })
+}
+
+/**
+ * @param {object} config - Config
+ * @param {object} [options] - { stderr }
+ */
+async function ensureDaemon(config, options = {}) {
+  try {
+    const pong = await ping(config)
+    warnVersionMismatch(pong, options.stderr)
+    return pong
+  } catch (err) {
+    if (/Unsafe op-cache socket/.test(err.message)) throw err
+    spawnDaemon(config)
+    const start = Date.now()
+    while (Date.now() - start < 5000) {
+      await sleep(50)
+      try {
+        const pong = await ping(config)
+        warnVersionMismatch(pong, options.stderr)
+        return pong
+      } catch (pollErr) {
+        // keep polling
+      }
+    }
+    throw new DaemonUnavailableError('op-cache daemon failed to start within 5s.')
+  }
+}
+
+/**
+ * @param {object} config - Config
+ */
+function spawnDaemon(config) {
+  const child = spawn(process.execPath, [require.resolve('./cli'), 'daemon'], {
+    detached: true,
+    stdio: 'ignore',
+    env: { ...process.env, OP_CACHE_SOCKET_PATH: config.socket_path },
+  })
+  child.unref()
+}
+
+/**
+ * @param {string} socketPath - Path
+ */
+function assertSafeSocket(socketPath) {
+  let stat
+  try {
+    stat = fs.statSync(socketPath)
+  } catch (err) {
+    throw new DaemonUnavailableError('op-cache daemon is not running.')
+  }
+  if (!stat.isSocket()) throw new DaemonUnavailableError(`Unsafe op-cache socket path is not a socket: ${socketPath}`)
+  if (typeof process.getuid === 'function' && stat.uid !== process.getuid()) {
+    throw new DaemonUnavailableError(`Unsafe op-cache socket owner for ${socketPath}.`)
+  }
+  const mode = stat.mode & 0o777
+  if (mode !== 0o600) throw new DaemonUnavailableError(`Unsafe op-cache socket permissions ${mode.toString(8)} for ${socketPath}; expected 600.`)
+}
+
+/**
+ * @param {object} pong - Pong response
+ * @param {NodeJS.WritableStream} [stderr] - stderr stream
+ */
+function warnVersionMismatch(pong, stderr) {
+  if (pong && pong.version && pong.version !== pkg.version && stderr) {
+    stderr.write(`op-cache: daemon version ${pong.version} differs from client version ${pkg.version}; run op-cache stop to reload\n`)
+  }
+}
+
+/**
+ * @param {number} ms - Milliseconds
+ * @returns {Promise<void>}
+ */
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+module.exports = { request, ping, ensureDaemon, assertSafeSocket, warnVersionMismatch, sleep }

--- a/packages/op-cache/src/config.js
+++ b/packages/op-cache/src/config.js
@@ -1,0 +1,145 @@
+/* Resolves op-cache configuration from flags, env, JSON config, and defaults.
+   Caches process-level config while allowing per-call option overrides. */
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { ConfigError } = require('./errors')
+const { parseDurationSeconds } = require('./duration')
+
+/** @type {import('fs')} */
+const fsp = fs
+
+/** @type {object|undefined} */
+let cachedBase
+
+/**
+ * @param {NodeJS.ProcessEnv} [env] - Environment object
+ * @returns {string} Config file path
+ */
+function configPath(env = process.env) {
+  if (env.OP_CACHE_CONFIG) return env.OP_CACHE_CONFIG
+  const base = env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config')
+  return path.join(base, 'op-cache', 'config.json')
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} [env] - Environment object
+ * @returns {object} Default config
+ */
+function defaults(env = process.env) {
+  const uid = typeof process.getuid === 'function' ? process.getuid() : 'user'
+  const tmp = env.TMPDIR || os.tmpdir() || '/tmp'
+  return {
+    socket_path: path.join(tmp, `op-cache-${uid}.sock`),
+    ttl_seconds: 300,
+    max_ttl_seconds: 86400,
+    max_entries: 1000,
+    op_path: 'op',
+    op_timeout_seconds: 30,
+    default_scope: 'user',
+    idle_exit_seconds: 1800,
+  }
+}
+
+/**
+ * @param {string} filePath - JSON config path
+ * @returns {object}
+ */
+function readConfigFile(filePath) {
+  if (!fsp.existsSync(filePath)) return {}
+  try {
+    const raw = fsp.readFileSync(filePath, 'utf8')
+    if (!raw.trim()) return {}
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new ConfigError(`Invalid op-cache config ${filePath}: expected a JSON object.`)
+    }
+    return parsed
+  } catch (err) {
+    if (err instanceof ConfigError) throw err
+    throw new ConfigError(`Invalid op-cache config ${filePath}: ${err.message}`)
+  }
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} env - Environment object
+ * @returns {object}
+ */
+function envConfig(env) {
+  const out = {}
+  if (env.OP_CACHE_SOCKET_PATH) out.socket_path = env.OP_CACHE_SOCKET_PATH
+  if (env.OP_CACHE_TTL_SECONDS) out.ttl_seconds = parseDurationSeconds(env.OP_CACHE_TTL_SECONDS, 'OP_CACHE_TTL_SECONDS')
+  if (env.OP_CACHE_MAX_TTL_SECONDS) out.max_ttl_seconds = parseDurationSeconds(env.OP_CACHE_MAX_TTL_SECONDS, 'OP_CACHE_MAX_TTL_SECONDS')
+  if (env.OP_CACHE_MAX_ENTRIES) out.max_entries = parsePositiveInt(env.OP_CACHE_MAX_ENTRIES, 'OP_CACHE_MAX_ENTRIES')
+  if (env.OP_CACHE_OP_PATH) out.op_path = env.OP_CACHE_OP_PATH
+  if (env.OP_CACHE_OP_TIMEOUT_SECONDS) out.op_timeout_seconds = parseDurationSeconds(env.OP_CACHE_OP_TIMEOUT_SECONDS, 'OP_CACHE_OP_TIMEOUT_SECONDS')
+  if (env.OP_CACHE_IDLE_EXIT_SECONDS) out.idle_exit_seconds = parseDurationSeconds(env.OP_CACHE_IDLE_EXIT_SECONDS, 'OP_CACHE_IDLE_EXIT_SECONDS')
+  if (env.OP_CACHE_SCOPE) out.default_scope = env.OP_CACHE_SCOPE
+  return out
+}
+
+/**
+ * @param {string|number} value - User integer value
+ * @param {string} label - Error label
+ * @returns {number}
+ */
+function parsePositiveInt(value, label) {
+  const n = Number(value)
+  if (Number.isInteger(n) && n > 0) return n
+  throw new ConfigError(`Invalid ${label}: expected a positive integer.`)
+}
+
+/**
+ * @param {object} config - Merged config
+ * @returns {object}
+ */
+function normalizeConfig(config) {
+  const out = { ...config }
+  for (const key of ['ttl_seconds', 'max_ttl_seconds', 'max_entries', 'op_timeout_seconds', 'idle_exit_seconds']) {
+    out[key] = parsePositiveInt(out[key], key)
+  }
+  if (!out.socket_path || typeof out.socket_path !== 'string') throw new ConfigError('Invalid socket_path: expected a non-empty string.')
+  if (!out.op_path || typeof out.op_path !== 'string') throw new ConfigError('Invalid op_path: expected a non-empty string.')
+  if (!out.default_scope || typeof out.default_scope !== 'string') throw new ConfigError('Invalid default_scope: expected a non-empty string.')
+  return out
+}
+
+/**
+ * @param {object} [flags] - CLI/API overrides
+ * @param {object} [settings] - { env, useCache }
+ * @returns {{config: object, path: string, exists: boolean}}
+ */
+function resolveConfig(flags = {}, settings = {}) {
+  const env = settings.env || process.env
+  const filePath = flags.configPath || configPath(env)
+  let base
+  if (settings.useCache !== false && cachedBase && !flags.configPath) {
+    base = cachedBase
+  } else {
+    base = normalizeConfig({
+      ...defaults(env),
+      ...readConfigFile(filePath),
+      ...envConfig(env),
+    })
+    if (settings.useCache !== false && !flags.configPath) cachedBase = base
+  }
+
+  const overrides = {}
+  if (flags.socketPath) overrides.socket_path = flags.socketPath
+  if (flags.ttlSeconds !== undefined) overrides.ttl_seconds = parseDurationSeconds(flags.ttlSeconds, 'ttl')
+  if (flags.maxTtlSeconds !== undefined) overrides.max_ttl_seconds = parseDurationSeconds(flags.maxTtlSeconds, 'max ttl')
+  if (flags.maxEntries !== undefined) overrides.max_entries = parsePositiveInt(flags.maxEntries, 'max entries')
+  if (flags.opPath) overrides.op_path = flags.opPath
+  if (flags.opTimeoutSeconds !== undefined) overrides.op_timeout_seconds = parseDurationSeconds(flags.opTimeoutSeconds, 'op timeout')
+  if (flags.idleExitSeconds !== undefined) overrides.idle_exit_seconds = parseDurationSeconds(flags.idleExitSeconds, 'idle exit')
+  if (flags.scope) overrides.default_scope = flags.scope
+
+  const config = normalizeConfig({ ...base, ...overrides })
+  return { config, path: filePath, exists: fsp.existsSync(filePath) }
+}
+
+function resetConfigCache() {
+  cachedBase = undefined
+}
+
+module.exports = { configPath, defaults, resolveConfig, resetConfigCache, parsePositiveInt }

--- a/packages/op-cache/src/daemon.js
+++ b/packages/op-cache/src/daemon.js
@@ -116,10 +116,17 @@ function handleLine(line, socket, cache, config, server) {
   }
 }
 
+// sun_path caps Unix socket paths (~104 bytes on macOS, ~108 on Linux);
+// over-long paths bind truncated and fail with misleading ENOENT errors.
+const MAX_SOCKET_PATH_BYTES = 100
+
 /**
  * @param {string} socketPath - Socket path
  */
 function prepareSocket(socketPath) {
+  if (Buffer.byteLength(socketPath) > MAX_SOCKET_PATH_BYTES) {
+    throw new DaemonUnavailableError(`Socket path exceeds ${MAX_SOCKET_PATH_BYTES} bytes; Unix sockets require short paths. Set OP_CACHE_SOCKET_PATH to a shorter location: ${socketPath}`)
+  }
   fs.mkdirSync(path.dirname(socketPath), { recursive: true })
   if (!fs.existsSync(socketPath)) return
   try {

--- a/packages/op-cache/src/daemon.js
+++ b/packages/op-cache/src/daemon.js
@@ -50,13 +50,15 @@ function startDaemon(config, options = {}) {
           server.close()
         }
       }, 1000)
+      const shutdown = () => server.close()
       const cleanup = () => {
         clearInterval(sweepTimer)
         clearInterval(idleTimer)
+        process.removeListener('SIGTERM', shutdown)
+        process.removeListener('SIGINT', shutdown)
         cleanupSocket(config.socket_path)
       }
       server.on('close', cleanup)
-      const shutdown = () => server.close()
       process.once('SIGTERM', shutdown)
       process.once('SIGINT', shutdown)
       if (options.foreground && process.env.DEBUG) process.stderr.write(`op-cache: daemon listening on ${config.socket_path}\n`)

--- a/packages/op-cache/src/daemon.js
+++ b/packages/op-cache/src/daemon.js
@@ -1,0 +1,146 @@
+/* Unix socket daemon that stores op-cache secrets in memory only.
+   Handles NDJSON cache requests and never executes the op CLI. */
+const fs = require('fs')
+const net = require('net')
+const path = require('path')
+const { SecretCache } = require('./cache')
+const { encode, decode, validateRequest, MAX_LINE_BYTES } = require('./protocol')
+const { DaemonUnavailableError } = require('./errors')
+const pkg = require('../package.json')
+
+/**
+ * @param {object} config - Effective config
+ * @param {object} [options] - { foreground }
+ * @returns {Promise<object>} Server handle
+ */
+function startDaemon(config, options = {}) {
+  return new Promise((resolve, reject) => {
+    prepareSocket(config.socket_path)
+    const cache = new SecretCache({ maxEntries: config.max_entries })
+    let lastConnectionAt = Date.now()
+    const server = net.createServer((socket) => {
+      lastConnectionAt = Date.now()
+      let buffer = ''
+      socket.on('data', (chunk) => {
+        buffer += chunk.toString('utf8')
+        if (Buffer.byteLength(buffer) > MAX_LINE_BYTES) {
+          socket.end(encode({ type: 'error', message: 'Protocol message too large.' }))
+          return
+        }
+        const index = buffer.indexOf('\n')
+        if (index === -1) return
+        const line = buffer.slice(0, index)
+        handleLine(line, socket, cache, config, server)
+      })
+    })
+
+    server.on('error', reject)
+    server.listen(config.socket_path, () => {
+      try {
+        fs.chmodSync(config.socket_path, 0o600)
+        fs.writeFileSync(pidPath(config.socket_path), String(process.pid), { mode: 0o600 })
+      } catch (err) {
+        server.close()
+        return reject(err)
+      }
+      server.off('error', reject)
+      const sweepTimer = setInterval(() => cache.sweep(), 1000)
+      const idleTimer = setInterval(() => {
+        if (cache.isEmpty() && Date.now() - lastConnectionAt >= config.idle_exit_seconds * 1000) {
+          server.close()
+        }
+      }, 1000)
+      const cleanup = () => {
+        clearInterval(sweepTimer)
+        clearInterval(idleTimer)
+        cleanupSocket(config.socket_path)
+      }
+      server.on('close', cleanup)
+      const shutdown = () => server.close()
+      process.once('SIGTERM', shutdown)
+      process.once('SIGINT', shutdown)
+      if (options.foreground && process.env.DEBUG) process.stderr.write(`op-cache: daemon listening on ${config.socket_path}\n`)
+      resolve({ server, cache })
+    })
+  })
+}
+
+/**
+ * @param {string} line - Request line
+ * @param {net.Socket} socket - Socket
+ * @param {SecretCache} cache - Cache
+ * @param {object} config - Config
+ * @param {net.Server} server - Server
+ */
+function handleLine(line, socket, cache, config, server) {
+  try {
+    const req = validateRequest(decode(line))
+    if (req.type === 'get') {
+      const value = cache.get(req.key)
+      return socket.end(encode(value === undefined ? { type: 'miss' } : { type: 'hit', value }))
+    }
+    if (req.type === 'set') {
+      const ttlSeconds = Math.min(req.ttlSeconds, config.max_ttl_seconds)
+      cache.set(req.key, req.value, {
+        ttlSeconds,
+        scope: req.scope,
+        ownerPid: req.ownerPid,
+        refHash: req.refHash,
+        accountHash: req.accountHash,
+      })
+      return socket.end(encode({ type: 'stored', ttlSeconds, clamped: ttlSeconds !== req.ttlSeconds }))
+    }
+    if (req.type === 'ping') {
+      return socket.end(encode({
+        type: 'pong',
+        version: pkg.version,
+        ttlSeconds: config.ttl_seconds,
+        maxTtlSeconds: config.max_ttl_seconds,
+        maxEntries: config.max_entries,
+        idleExitSeconds: config.idle_exit_seconds,
+      }))
+    }
+    if (req.type === 'clear') {
+      return socket.end(encode({ type: 'cleared', removed: cache.clear(req.scope) }))
+    }
+    if (req.type === 'stats') {
+      return socket.end(encode({ type: 'stats', ...cache.stats(req.scope) }))
+    }
+    if (req.type === 'shutdown') {
+      socket.end(encode({ type: 'shutting_down' }), () => server.close())
+    }
+  } catch (err) {
+    socket.end(encode({ type: 'error', message: err.message }))
+  }
+}
+
+/**
+ * @param {string} socketPath - Socket path
+ */
+function prepareSocket(socketPath) {
+  fs.mkdirSync(path.dirname(socketPath), { recursive: true })
+  if (!fs.existsSync(socketPath)) return
+  try {
+    const stat = fs.statSync(socketPath)
+    if (stat.isSocket()) fs.unlinkSync(socketPath)
+    else throw new DaemonUnavailableError(`Refusing to remove non-socket path: ${socketPath}`)
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err
+  }
+}
+
+function pidPath(socketPath) {
+  return `${socketPath}.pid`
+}
+
+function cleanupSocket(socketPath) {
+  for (const file of [socketPath, pidPath(socketPath)]) {
+    try {
+      fs.unlinkSync(file)
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err
+    }
+  }
+}
+
+module.exports = { startDaemon, pidPath, cleanupSocket }

--- a/packages/op-cache/src/duration.js
+++ b/packages/op-cache/src/duration.js
@@ -1,0 +1,29 @@
+/* Parses user-facing TTL duration strings.
+   Accepts seconds, minutes, and hours with strict positive integer rules. */
+const { UsageError } = require('./errors')
+
+const ACCEPTED = 'Accepted formats: 30s, 5m, 1h, or bare seconds like 300.'
+
+/**
+ * @param {string|number|undefined} value - Duration input
+ * @param {string} [label] - Label for error messages
+ * @returns {number|undefined} Positive integer seconds
+ */
+function parseDurationSeconds(value, label = 'duration') {
+  if (value === undefined || value === null || value === '') return undefined
+  if (typeof value === 'number') {
+    if (Number.isInteger(value) && value > 0) return value
+    throw new UsageError(`Invalid ${label}: ${value}. ${ACCEPTED}`)
+  }
+  const input = String(value).trim()
+  const match = input.match(/^([1-9][0-9]*)([smh]?)$/)
+  if (!match) {
+    throw new UsageError(`Invalid ${label}: ${input}. ${ACCEPTED}`)
+  }
+  const n = Number(match[1])
+  const unit = match[2] || 's'
+  const multiplier = unit === 'h' ? 3600 : unit === 'm' ? 60 : 1
+  return n * multiplier
+}
+
+module.exports = { parseDurationSeconds, ACCEPTED }

--- a/packages/op-cache/src/errors.js
+++ b/packages/op-cache/src/errors.js
@@ -1,0 +1,26 @@
+/* Error classes for op-cache callers.
+   Keeps daemon, scope, and op execution failures distinguishable. */
+
+class OpCacheError extends Error {
+  constructor(message) {
+    super(message)
+    this.name = this.constructor.name
+  }
+}
+
+class DaemonUnavailableError extends OpCacheError {}
+class OpExecError extends OpCacheError {}
+class ScopeError extends OpCacheError {}
+class ConfigError extends OpCacheError {}
+class ProtocolError extends OpCacheError {}
+class UsageError extends OpCacheError {}
+
+module.exports = {
+  OpCacheError,
+  DaemonUnavailableError,
+  OpExecError,
+  ScopeError,
+  ConfigError,
+  ProtocolError,
+  UsageError,
+}

--- a/packages/op-cache/src/key.js
+++ b/packages/op-cache/src/key.js
@@ -1,0 +1,54 @@
+/* Builds opaque cache keys for 1Password references.
+   Hashes account, op config, binary identity, scope, and ref client-side. */
+const crypto = require('crypto')
+const fs = require('fs')
+
+const KEY_VERSION = 'v1'
+
+/**
+ * @param {string|undefined} explicit - Explicit account
+ * @param {NodeJS.ProcessEnv} [env] - Environment object
+ * @returns {string}
+ */
+function effectiveAccount(explicit, env = process.env) {
+  if (explicit) return explicit
+  return env.OP_ACCOUNT || ''
+}
+
+/**
+ * @param {string} opPath - op binary path/name
+ * @returns {string}
+ */
+function opIdentity(opPath) {
+  try {
+    return fs.realpathSync(opPath)
+  } catch (err) {
+    return opPath
+  }
+}
+
+/**
+ * @param {object} params - Key inputs
+ * @returns {string}
+ */
+function cacheKey(params) {
+  const parts = [
+    KEY_VERSION,
+    params.scope || '',
+    params.account || '',
+    params.configDir || '',
+    opIdentity(params.opPath || 'op'),
+    params.reference || '',
+  ]
+  return `sha256:${crypto.createHash('sha256').update(parts.join('\0')).digest('hex')}`
+}
+
+/**
+ * @param {string} value - String to hash for stats metadata
+ * @returns {string}
+ */
+function shortHash(value) {
+  return crypto.createHash('sha256').update(value || '').digest('hex').slice(0, 16)
+}
+
+module.exports = { KEY_VERSION, effectiveAccount, cacheKey, opIdentity, shortHash }

--- a/packages/op-cache/src/op.js
+++ b/packages/op-cache/src/op.js
@@ -1,0 +1,76 @@
+/* Executes the 1Password CLI for op-cache misses.
+   Uses op read --no-newline and sanitized errors. */
+const { spawn } = require('child_process')
+const { OpExecError } = require('./errors')
+
+const AUTH_ERROR_PATTERN = /sign ?in|session|authoriz|authenticat|not currently signed|locked|service account token/i
+const NOT_FOUND_PATTERN = /isn'?t an? (item|vault)|not found|no item|no vault|doesn'?t exist|does not have a field|more than one item/i
+
+/**
+ * @param {string} ref - op:// reference
+ * @param {object} config - op-cache config
+ * @param {object} [opts] - { account }
+ * @returns {Promise<string>}
+ */
+function readOp(ref, config, opts = {}) {
+  const args = ['read', '--no-newline', ref]
+  if (opts.account) args.push('--account', opts.account)
+  if (opts.configDir) args.push('--config', opts.configDir)
+  return run(config.op_path || 'op', args, config.op_timeout_seconds || 30, ref)
+}
+
+/**
+ * @param {string} binary - Binary
+ * @param {string[]} args - Args
+ * @param {number} timeoutSeconds - Timeout
+ * @param {string} ref - Subject ref
+ * @returns {Promise<string>}
+ */
+function run(binary, args, timeoutSeconds, ref) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binary, args, { stdio: ['ignore', 'pipe', 'pipe'] })
+    const stdout = []
+    const stderr = []
+    let settled = false
+    const timer = setTimeout(() => {
+      if (settled) return
+      settled = true
+      child.kill('SIGTERM')
+      reject(new OpExecError(`1Password CLI read timed out after ${timeoutSeconds}s for ${ref}.`))
+    }, timeoutSeconds * 1000)
+    child.stdout.on('data', (chunk) => stdout.push(chunk))
+    child.stderr.on('data', (chunk) => stderr.push(chunk))
+    child.on('error', (err) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (err.code === 'ENOENT') reject(new OpExecError('1Password CLI "op" was not found on PATH. Install 1Password CLI or configure op_path.'))
+      else reject(new OpExecError('1Password CLI command failed.'))
+    })
+    child.on('close', (code) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (code === 0) return resolve(Buffer.concat(stdout).toString('utf8'))
+      reject(translateError(Buffer.concat(stderr).toString('utf8'), ref))
+    })
+  })
+}
+
+/**
+ * @param {string} stderr - stderr
+ * @param {string} ref - Subject ref
+ * @returns {OpExecError}
+ */
+function translateError(stderr, ref) {
+  const detail = String(stderr || '')
+  if (AUTH_ERROR_PATTERN.test(detail)) {
+    return new OpExecError('1Password CLI could not read the item. Run op signin, unlock 1Password app integration, or configure OP_SERVICE_ACCOUNT_TOKEN.')
+  }
+  if (NOT_FOUND_PATTERN.test(detail)) {
+    return new OpExecError(`1Password item, vault, or field could not be found ("${ref}").`)
+  }
+  return new OpExecError('1Password CLI command failed.')
+}
+
+module.exports = { readOp, translateError }

--- a/packages/op-cache/src/protocol.js
+++ b/packages/op-cache/src/protocol.js
@@ -1,0 +1,48 @@
+/* NDJSON protocol helpers for daemon/client messages.
+   Validates request shape and caps line length before parsing. */
+const { ProtocolError } = require('./errors')
+
+const MAX_LINE_BYTES = 1024 * 1024
+const REQUEST_TYPES = new Set(['get', 'set', 'ping', 'clear', 'stats', 'shutdown'])
+
+/**
+ * @param {object} message - Message object
+ * @returns {string}
+ */
+function encode(message) {
+  return `${JSON.stringify(message)}\n`
+}
+
+/**
+ * @param {string|Buffer} line - NDJSON line
+ * @returns {object}
+ */
+function decode(line) {
+  const text = Buffer.isBuffer(line) ? line.toString('utf8') : String(line)
+  if (Buffer.byteLength(text) > MAX_LINE_BYTES) throw new ProtocolError('Protocol message too large.')
+  try {
+    return JSON.parse(text)
+  } catch (err) {
+    throw new ProtocolError('Malformed JSON protocol message.')
+  }
+}
+
+/**
+ * @param {object} req - Request object
+ * @returns {object}
+ */
+function validateRequest(req) {
+  if (!req || typeof req !== 'object' || !REQUEST_TYPES.has(req.type)) {
+    throw new ProtocolError('Unknown protocol request type.')
+  }
+  if ((req.type === 'get' || req.type === 'set') && (!req.key || !req.scope)) {
+    throw new ProtocolError(`${req.type} request requires key and scope.`)
+  }
+  if (req.type === 'set') {
+    if (typeof req.value !== 'string') throw new ProtocolError('set request requires string value.')
+    if (!Number.isInteger(req.ttlSeconds) || req.ttlSeconds <= 0) throw new ProtocolError('set request requires positive ttlSeconds.')
+  }
+  return req
+}
+
+module.exports = { MAX_LINE_BYTES, encode, decode, validateRequest }

--- a/packages/op-cache/src/scope.js
+++ b/packages/op-cache/src/scope.js
@@ -1,0 +1,43 @@
+/* Resolves cache scope strings and process ownership metadata.
+   Keeps agent/session isolation explicit instead of PID-only. */
+const { ScopeError } = require('./errors')
+
+/**
+ * @param {string|undefined} requested - Requested scope
+ * @param {object} [settings] - { env, pid, ppid }
+ * @returns {{scope: string, ownerPid: number|undefined, kind: string}}
+ */
+function resolveScope(requested, settings = {}) {
+  const env = settings.env || process.env
+  const pid = settings.pid || process.pid
+  const ppid = settings.ppid || process.ppid
+  const raw = requested || env.OP_CACHE_SCOPE || 'user'
+  if (raw === 'user') return { scope: 'user', ownerPid: undefined, kind: 'user' }
+  if (raw === 'pid') return { scope: `pid:${pid}`, ownerPid: pid, kind: 'pid' }
+  if (raw === 'ppid') return { scope: `ppid:${ppid}`, ownerPid: ppid, kind: 'ppid' }
+  if (raw === 'session') {
+    const session = env.OP_CACHE_SESSION || env.OP_CACHE_SCOPE
+    if (!session || session === 'session') {
+      throw new ScopeError('Scope "session" requires OP_CACHE_SESSION or inline --scope session:<name>.')
+    }
+    return { scope: normalizeSession(session), ownerPid: undefined, kind: 'session' }
+  }
+  if (raw.startsWith('session:')) {
+    if (raw.length === 'session:'.length) {
+      throw new ScopeError('Scope "session:" requires a non-empty session name.')
+    }
+    return { scope: raw, ownerPid: undefined, kind: 'session' }
+  }
+  if (!String(raw).trim()) throw new ScopeError('Scope must be a non-empty string.')
+  return { scope: String(raw), ownerPid: undefined, kind: 'custom' }
+}
+
+/**
+ * @param {string} value - Session env or inline value
+ * @returns {string}
+ */
+function normalizeSession(value) {
+  return value.startsWith('session:') ? value : `session:${value}`
+}
+
+module.exports = { resolveScope }

--- a/packages/op-cache/test/cli.test.js
+++ b/packages/op-cache/test/cli.test.js
@@ -1,0 +1,109 @@
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const fs = require('fs')
+const path = require('path')
+const { tempDir, fakeOp, cliEnv, runCli, stopDaemon } = require('./helpers')
+const { main } = require('../src/cli')
+
+test('help prints usage', () => {
+  const r = runCli(['--help'], process.env)
+  assert.is(r.status, 0)
+  assert.match(r.stdout, /Usage:/)
+})
+
+test('read prints only secret to stdout and hits cache on second process', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir, { value: 's3cret' })
+  const env = cliEnv(dir, fake)
+  try {
+    const first = runCli(['read', 'op://vault/item/field'], env)
+    assert.is(first.status, 0, first.stderr)
+    assert.is(first.stdout, 's3cret\n')
+    assert.is(fake.calls(), 1)
+    const second = runCli(['read', 'op://vault/item/field'], env)
+    assert.is(second.status, 0, second.stderr)
+    assert.is(second.stdout, 's3cret\n')
+    assert.is(fake.calls(), 1)
+  } finally {
+    stopDaemon(env)
+  }
+})
+
+test('status stats clear stop json lifecycle', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = cliEnv(dir, fake)
+  try {
+    const stopped = runCli(['status', '--json'], env)
+    assert.equal(JSON.parse(stopped.stdout).running, false)
+    runCli(['read', 'op://vault/item/field'], env)
+    const status = JSON.parse(runCli(['status', '--json'], env).stdout)
+    assert.is(status.running, true)
+    const stats = JSON.parse(runCli(['stats', '--json'], env).stdout)
+    assert.ok(Object.keys(stats).includes('entries'))
+    assert.is(String(runCli(['stats'], env).stdout).includes('op://'), false)
+    const clear = runCli(['clear'], env)
+    assert.match(clear.stdout, /removed:/)
+    assert.is(runCli(['stop'], env).status, 0)
+    assert.match(runCli(['clear'], env).stdout, /daemon not running/)
+  } finally {
+    stopDaemon(env)
+  }
+})
+
+test('ttl clamp warning stays on stderr', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir, { value: 'secret' })
+  const env = cliEnv(dir, fake)
+  try {
+    const r = runCli(['read', 'op://vault/item/field', '--ttl', '1h'], env)
+    assert.is(r.status, 0, r.stderr)
+    assert.is(r.stdout, 'secret\n')
+    assert.match(r.stderr, /ttl clamped/)
+  } finally {
+    stopDaemon(env)
+  }
+})
+
+test('OP_CACHE_DISABLED bypasses daemon', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = { ...cliEnv(dir, fake), OP_CACHE_DISABLED: '1' }
+  const r = runCli(['read', 'op://vault/item/field'], env)
+  assert.is(r.status, 0, r.stderr)
+  assert.is(fake.calls(), 1)
+  assert.is(fs.existsSync(path.join(dir, 'cache.sock')), false)
+})
+
+test('doctor and config-path are machine readable', () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = { ...cliEnv(dir, fake), OP_SERVICE_ACCOUNT_TOKEN: 'dont-print-me' }
+  const doctor = runCli(['doctor', '--json'], env)
+  const json = JSON.parse(doctor.stdout)
+  assert.is(json.serviceAccountTokenSet, true)
+  assert.is(doctor.stdout.includes('dont-print-me'), false)
+  const configPath = runCli(['config-path'], env)
+  assert.match(configPath.stdout, /config\.json\n$/)
+})
+
+test('bad command exits nonzero with usage on stderr', () => {
+  const r = runCli(['wat'], process.env)
+  assert.is(r.status, 2)
+  assert.match(r.stderr, /unknown command/)
+})
+
+test('win32 passthrough reports unavailable without touching socket for diagnostics', async () => {
+  const out = []
+  const err = []
+  await main(['status', '--json'], {
+    platform: 'win32',
+    stdout: { write: (chunk) => out.push(String(chunk)) },
+    stderr: { write: (chunk) => err.push(String(chunk)) },
+  })
+  const json = JSON.parse(out.join(''))
+  assert.is(json.available, false)
+  assert.is(json.platform, 'win32')
+})
+
+test.run()

--- a/packages/op-cache/test/get-or-set.test.js
+++ b/packages/op-cache/test/get-or-set.test.js
@@ -1,0 +1,292 @@
+/* Tests for the getOrSet advanced integration API.
+   Uses in-process daemons on temp sockets; producers are plain functions. */
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const fs = require('fs')
+const path = require('path')
+const { getOrSet, start } = require('../src/api')
+const { shortHash } = require('../src/key')
+const { tempDir, stopDaemon } = require('./helpers')
+
+function makeEnv(dir, overrides = {}) {
+  const env = {
+    ...process.env,
+    OP_CACHE_SOCKET_PATH: path.join(dir, 'cache.sock'),
+    OP_CACHE_TTL_SECONDS: '60',
+    OP_CACHE_MAX_TTL_SECONDS: '60',
+    OP_CACHE_IDLE_EXIT_SECONDS: '30',
+    XDG_CONFIG_HOME: path.join(dir, 'xdg'),
+    ...overrides,
+  }
+  delete env.OP_CACHE_DISABLED
+  delete env.OP_ACCOUNT
+  delete env.OP_SERVICE_ACCOUNT_TOKEN
+  return env
+}
+
+function fakeStderr() {
+  const chunks = []
+  return { chunks, write(chunk) { chunks.push(String(chunk)); return true }, text: () => chunks.join('') }
+}
+
+function producerOf(values) {
+  let calls = 0
+  const fn = async () => {
+    calls += 1
+    return Array.isArray(values) ? values[Math.min(calls - 1, values.length - 1)] : values
+  }
+  fn.calls = () => calls
+  return fn
+}
+
+async function withDaemon(env, opts, fn) {
+  const handle = await start({ env, socketPath: env.OP_CACHE_SOCKET_PATH, ...opts })
+  try {
+    return await fn(handle)
+  } finally {
+    handle.server.close()
+  }
+}
+
+test('miss runs producer once and stores; hit does not run producer', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const producer = producerOf('resolved-value')
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:a' }
+    assert.is(await getOrSet('configorama-op://v1/abc', producer, opts), 'resolved-value')
+    assert.is(await getOrSet('configorama-op://v1/abc', producer, opts), 'resolved-value')
+    assert.is(producer.calls(), 1)
+  })
+})
+
+test('validateCached rejection recomputes and overwrites the entry', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:v' }
+    await getOrSet('ref-v', producerOf('old-value'), opts)
+    const second = producerOf('new-value')
+    const stderr = fakeStderr()
+    const rejected = await getOrSet('ref-v', second, { ...opts, stderr, validateCached: () => false })
+    assert.is(rejected, 'new-value')
+    assert.is(second.calls(), 1)
+    // Overwrite proven: a passing validator now sees the new value with no producer call
+    const third = producerOf('unused')
+    assert.is(await getOrSet('ref-v', third, { ...opts, validateCached: () => true }), 'new-value')
+    assert.is(third.calls(), 0)
+    assert.ok(stderr.text().includes('failed validation'))
+  })
+})
+
+test('validateCached rejection warns at most once per stderr stream', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const stderr = fakeStderr()
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:w', stderr, validateCached: () => false }
+    await getOrSet('ref-w', producerOf('v1'), opts)
+    await getOrSet('ref-w', producerOf('v2'), opts)
+    await getOrSet('ref-w', producerOf('v3'), opts)
+    const notes = stderr.chunks.filter((c) => c.includes('failed validation'))
+    assert.is(notes.length, 1)
+  })
+})
+
+test('validateCached throwing behaves as rejection', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:t' }
+    await getOrSet('ref-t', producerOf('first'), opts)
+    const second = producerOf('second')
+    const value = await getOrSet('ref-t', second, { ...opts, validateCached: () => { throw new Error('boom') } })
+    assert.is(value, 'second')
+    assert.is(second.calls(), 1)
+  })
+})
+
+test('producer rejection is not cached and surfaces the producer error', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:e' }
+    let failCalls = 0
+    try {
+      await getOrSet('ref-e', async () => { failCalls += 1; throw new Error('producer failed sanitized') }, opts)
+      assert.unreachable('should throw')
+    } catch (err) {
+      assert.is(err.message, 'producer failed sanitized')
+    }
+    assert.is(failCalls, 1)
+    const recovery = producerOf('recovered')
+    assert.is(await getOrSet('ref-e', recovery, opts), 'recovered')
+    assert.is(recovery.calls(), 1)
+  })
+})
+
+test('non-string producer result throws and stores nothing', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:n' }
+    try {
+      await getOrSet('ref-n', async () => 42, opts)
+      assert.unreachable('should throw')
+    } catch (err) {
+      assert.match(err.message, /must return a string/)
+    }
+    const recovery = producerOf('string-now')
+    assert.is(await getOrSet('ref-n', recovery, opts), 'string-now')
+    assert.is(recovery.calls(), 1)
+  })
+})
+
+test('daemon failure fails closed by default without running the producer', async () => {
+  const dir = tempDir()
+  const badSocket = path.join(dir, 'not-a-socket')
+  fs.writeFileSync(badSocket, 'x')
+  const env = makeEnv(dir, { OP_CACHE_SOCKET_PATH: badSocket })
+  const producer = producerOf('never')
+  try {
+    await getOrSet('ref-f', producer, { env, socketPath: badSocket, fallbackToOp: false })
+    assert.unreachable('should throw')
+  } catch (err) {
+    assert.match(err.message, /socket/)
+  }
+  assert.is(producer.calls(), 0)
+})
+
+test('daemon failure with fallbackToOp runs producer and warns', async () => {
+  const dir = tempDir()
+  const badSocket = path.join(dir, 'not-a-socket')
+  fs.writeFileSync(badSocket, 'x')
+  const env = makeEnv(dir, { OP_CACHE_SOCKET_PATH: badSocket })
+  const stderr = fakeStderr()
+  const producer = producerOf('direct-value')
+  const value = await getOrSet('ref-f2', producer, { env, socketPath: badSocket, fallbackToOp: true, stderr })
+  assert.is(value, 'direct-value')
+  assert.is(producer.calls(), 1)
+  assert.ok(stderr.text().includes('cache bypassed'))
+})
+
+test('ttl expiration causes producer to run again', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir, { OP_CACHE_TTL_SECONDS: '1', OP_CACHE_MAX_TTL_SECONDS: '1' })
+  await withDaemon(env, { ttlSeconds: 1, maxTtlSeconds: 1 }, async () => {
+    const producer = producerOf('short-lived')
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:ttl' }
+    await getOrSet('ref-ttl', producer, opts)
+    await new Promise((resolve) => setTimeout(resolve, 1100))
+    await getOrSet('ref-ttl', producer, opts)
+    assert.is(producer.calls(), 2)
+  })
+})
+
+test('scopes are isolated', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const producer = producerOf('scoped')
+    const base = { env, socketPath: env.OP_CACHE_SOCKET_PATH }
+    await getOrSet('ref-s', producer, { ...base, scope: 'session:one' })
+    await getOrSet('ref-s', producer, { ...base, scope: 'session:two' })
+    assert.is(producer.calls(), 2)
+  })
+})
+
+test('account, configDir, and opPath partition the cache key', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const producer = producerOf('partitioned')
+    const base = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:p' }
+    await getOrSet('ref-p', producer, base)
+    await getOrSet('ref-p', producer, { ...base, account: 'other.1password.com' })
+    await getOrSet('ref-p', producer, { ...base, configDir: path.join(dir, 'other-config') })
+    await getOrSet('ref-p', producer, { ...base, opPath: path.join(dir, 'other-op') })
+    assert.is(producer.calls(), 4)
+    // Same dimensions again: all hits
+    await getOrSet('ref-p', producer, base)
+    assert.is(producer.calls(), 4)
+  })
+})
+
+test('OP_CACHE_DISABLED=1 runs producer directly and never touches the daemon', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir, { OP_CACHE_DISABLED: '1' })
+  env.OP_CACHE_DISABLED = '1'
+  const producer = producerOf('disabled-value')
+  const value = await getOrSet('ref-d', producer, { env, socketPath: env.OP_CACHE_SOCKET_PATH })
+  assert.is(value, 'disabled-value')
+  assert.is(producer.calls(), 1)
+  assert.is(fs.existsSync(env.OP_CACHE_SOCKET_PATH), false)
+})
+
+test('win32 runs producer directly and never touches a socket', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  const producer = producerOf('win32-value')
+  const value = await getOrSet('ref-w32', producer, { env, socketPath: env.OP_CACHE_SOCKET_PATH, platform: 'win32' })
+  assert.is(value, 'win32-value')
+  assert.is(producer.calls(), 1)
+  assert.is(fs.existsSync(env.OP_CACHE_SOCKET_PATH), false)
+})
+
+test('ttl clamp warns at most once per stderr stream', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir, { OP_CACHE_TTL_SECONDS: '60', OP_CACHE_MAX_TTL_SECONDS: '60' })
+  await withDaemon(env, { maxTtlSeconds: 1 }, async () => {
+    const stderr = fakeStderr()
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:c', stderr }
+    await getOrSet('ref-c1', producerOf('a'), opts)
+    await getOrSet('ref-c2', producerOf('b'), opts)
+    const warnings = stderr.chunks.filter((c) => c.includes('ttl clamped'))
+    assert.is(warnings.length, 1)
+  })
+})
+
+test('set carries refHash and accountHash diagnostics', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async (handle) => {
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:h', account: 'my.1password.com' }
+    await getOrSet('configorama-op://v1/hashme', producerOf('x'), opts)
+    const entries = [...handle.cache.map.values()]
+    assert.is(entries.length, 1)
+    assert.is(entries[0].refHash, shortHash('configorama-op://v1/hashme'))
+    assert.is(entries[0].accountHash, shortHash('my.1password.com'))
+  })
+})
+
+test('non-op:// refs are accepted; empty refs are rejected', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  await withDaemon(env, {}, async () => {
+    const producer = producerOf('any-ref')
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:r' }
+    assert.is(await getOrSet('configorama-op://v1/deadbeef', producer, opts), 'any-ref')
+    try {
+      await getOrSet('', producer, opts)
+      assert.unreachable('should throw')
+    } catch (err) {
+      assert.match(err.message, /non-empty/)
+    }
+  })
+})
+
+test('auto-starts the daemon when none is running', async () => {
+  const dir = tempDir()
+  const env = makeEnv(dir)
+  try {
+    const producer = producerOf('spawned')
+    const opts = { env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:spawn' }
+    assert.is(await getOrSet('ref-spawn', producer, opts), 'spawned')
+    assert.is(await getOrSet('ref-spawn', producer, opts), 'spawned')
+    assert.is(producer.calls(), 1)
+  } finally {
+    stopDaemon(env)
+  }
+})
+
+test.run()

--- a/packages/op-cache/test/helpers.js
+++ b/packages/op-cache/test/helpers.js
@@ -1,0 +1,60 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const childProcess = require('child_process')
+
+function tempDir(prefix = 'op-cache-test-') {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+}
+
+function fakeOp(dir, options = {}) {
+  const bin = path.join(dir, 'fake-op.js')
+  const count = path.join(dir, 'count.txt')
+  const valueFile = path.join(dir, 'value.txt')
+  fs.writeFileSync(valueFile, options.value === undefined ? 'secret-value' : options.value)
+  fs.writeFileSync(count, '0')
+  fs.writeFileSync(bin, `#!/usr/bin/env node
+const fs = require('fs')
+const count = ${JSON.stringify(count)}
+const valueFile = ${JSON.stringify(valueFile)}
+const n = Number(fs.readFileSync(count, 'utf8') || '0') + 1
+fs.writeFileSync(count, String(n))
+if (process.env.FAKE_OP_FAIL) {
+  process.stderr.write(process.env.FAKE_OP_FAIL)
+  process.exit(1)
+}
+if (process.env.FAKE_OP_SLEEP) {
+  setTimeout(() => process.stdout.write(fs.readFileSync(valueFile, 'utf8')), Number(process.env.FAKE_OP_SLEEP))
+} else {
+  process.stdout.write(fs.readFileSync(valueFile, 'utf8'))
+}
+`)
+  fs.chmodSync(bin, 0o755)
+  return { bin, count, valueFile, calls: () => Number(fs.readFileSync(count, 'utf8') || '0') }
+}
+
+function cliEnv(dir, fake) {
+  return {
+    ...process.env,
+    OP_CACHE_SOCKET_PATH: path.join(dir, 'cache.sock'),
+    OP_CACHE_OP_PATH: fake.bin,
+    OP_CACHE_TTL_SECONDS: '2',
+    OP_CACHE_MAX_TTL_SECONDS: '2',
+    OP_CACHE_IDLE_EXIT_SECONDS: '1',
+    XDG_CONFIG_HOME: path.join(dir, 'xdg'),
+  }
+}
+
+function runCli(args, env, options = {}) {
+  return childProcess.spawnSync(process.execPath, [require.resolve('../src/cli'), ...args], {
+    env,
+    encoding: 'utf8',
+    timeout: options.timeout || 10000,
+  })
+}
+
+function stopDaemon(env) {
+  runCli(['stop'], env)
+}
+
+module.exports = { tempDir, fakeOp, cliEnv, runCli, stopDaemon }

--- a/packages/op-cache/test/integration.test.js
+++ b/packages/op-cache/test/integration.test.js
@@ -1,0 +1,63 @@
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const fs = require('fs')
+const path = require('path')
+const { read, stats, clear, status } = require('../src/api')
+const { tempDir, fakeOp, cliEnv, runCli, stopDaemon } = require('./helpers')
+
+test('programmatic API caches across calls and supports scoped stats/clear', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir, { value: 'api-secret' })
+  const env = cliEnv(dir, fake)
+  try {
+    const opts = { env, opPath: fake.bin, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:a', fallbackToOp: false }
+    assert.is(await read('op://vault/item/field', opts), 'api-secret')
+    assert.is(await read('op://vault/item/field', opts), 'api-secret')
+    assert.is(fake.calls(), 1)
+    assert.is((await stats({ env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:a' })).entries, 1)
+    assert.is((await clear({ env, socketPath: env.OP_CACHE_SOCKET_PATH, scope: 'session:a' })).removed, 1)
+  } finally {
+    stopDaemon(env)
+  }
+})
+
+test('fallbackToOp controls daemon failure behavior', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir, { value: 'fallback-secret' })
+  const socketPath = path.join(dir, 'not-a-socket')
+  fs.writeFileSync(socketPath, 'x')
+  const env = { ...cliEnv(dir, fake), OP_CACHE_SOCKET_PATH: socketPath }
+  try {
+    await read('op://vault/item/field', { env, opPath: fake.bin, socketPath, fallbackToOp: false })
+    assert.unreachable('should throw')
+  } catch (err) {
+    assert.match(err.message, /non-socket|socket/)
+  }
+  const value = await read('op://vault/item/field', { env, opPath: fake.bin, socketPath, fallbackToOp: true })
+  assert.is(value, 'fallback-secret')
+})
+
+test('ttl sweep expires entries without another read', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = { ...cliEnv(dir, fake), OP_CACHE_TTL_SECONDS: '1', OP_CACHE_MAX_TTL_SECONDS: '1', OP_CACHE_IDLE_EXIT_SECONDS: '5' }
+  try {
+    runCli(['read', 'op://vault/item/field'], env)
+    assert.is(JSON.parse(runCli(['stats', '--json'], env).stdout).entries, 1)
+    await new Promise((resolve) => setTimeout(resolve, 1600))
+    assert.is(JSON.parse(runCli(['stats', '--json'], env).stdout).entries, 0)
+  } finally {
+    stopDaemon(env)
+  }
+})
+
+test('idle daemon exits after cache empty', async () => {
+  const dir = tempDir()
+  const fake = fakeOp(dir)
+  const env = { ...cliEnv(dir, fake), OP_CACHE_TTL_SECONDS: '1', OP_CACHE_MAX_TTL_SECONDS: '1', OP_CACHE_IDLE_EXIT_SECONDS: '1' }
+  runCli(['read', 'op://vault/item/field'], env)
+  await new Promise((resolve) => setTimeout(resolve, 2600))
+  assert.is((await status({ env, socketPath: env.OP_CACHE_SOCKET_PATH })).running, false)
+})
+
+test.run()

--- a/packages/op-cache/test/unit.test.js
+++ b/packages/op-cache/test/unit.test.js
@@ -140,4 +140,15 @@ test('op stderr translation reports missing fields as not found', () => {
   assert.match(err.message, /op:\/\/vault\/item\/password/)
 })
 
+test('daemon rejects over-long socket paths with a clear error', async () => {
+  const { startDaemon } = require('../src/daemon')
+  const longPath = '/tmp/' + 'x'.repeat(120) + '.sock'
+  try {
+    await startDaemon({ socket_path: longPath, max_entries: 10, idle_exit_seconds: 30 })
+    assert.unreachable('should throw')
+  } catch (err) {
+    assert.match(err.message, /exceeds.*bytes.*OP_CACHE_SOCKET_PATH/s)
+  }
+})
+
 test.run()

--- a/packages/op-cache/test/unit.test.js
+++ b/packages/op-cache/test/unit.test.js
@@ -1,0 +1,143 @@
+const { test } = require('uvu')
+const assert = require('uvu/assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { parseDurationSeconds } = require('../src/duration')
+const { resolveScope } = require('../src/scope')
+const { cacheKey, effectiveAccount } = require('../src/key')
+const { SecretCache } = require('../src/cache')
+const { encode, decode, validateRequest } = require('../src/protocol')
+const { resolveConfig, resetConfigCache } = require('../src/config')
+const { translateError } = require('../src/op')
+
+test('duration parser accepts documented formats', () => {
+  assert.is(parseDurationSeconds('30s'), 30)
+  assert.is(parseDurationSeconds('5m'), 300)
+  assert.is(parseDurationSeconds('1h'), 3600)
+  assert.is(parseDurationSeconds('300'), 300)
+  assert.is(parseDurationSeconds(42), 42)
+})
+
+test('duration parser rejects invalid values with accepted formats', () => {
+  for (const value of ['0', '-1', '1.5', '1d', 'nope']) {
+    try {
+      parseDurationSeconds(value)
+      assert.unreachable('should reject')
+    } catch (err) {
+      assert.match(err.message, /Accepted formats/)
+    }
+  }
+})
+
+test('scope resolver supports user, session, pid, ppid, and custom', () => {
+  assert.equal(resolveScope('user'), { scope: 'user', ownerPid: undefined, kind: 'user' })
+  assert.equal(resolveScope('session:abc'), { scope: 'session:abc', ownerPid: undefined, kind: 'session' })
+  assert.equal(resolveScope('pid', { pid: 123 }), { scope: 'pid:123', ownerPid: 123, kind: 'pid' })
+  assert.equal(resolveScope('ppid', { ppid: 99 }), { scope: 'ppid:99', ownerPid: 99, kind: 'ppid' })
+  assert.equal(resolveScope('repo-x'), { scope: 'repo-x', ownerPid: undefined, kind: 'custom' })
+})
+
+test('session scope requires explicit session identity', () => {
+  try {
+    resolveScope('session', { env: {} })
+    assert.unreachable('should reject')
+  } catch (err) {
+    assert.match(err.message, /OP_CACHE_SESSION/)
+  }
+  assert.is(resolveScope('session', { env: { OP_CACHE_SCOPE: 'general', OP_CACHE_SESSION: 'specific' } }).scope, 'session:specific')
+})
+
+test('cache key changes on each dimension and account precedence matches op-cache rust behavior', () => {
+  const base = { scope: 'user', account: '', configDir: '', opPath: 'op', reference: 'op://vault/item/field' }
+  const key = cacheKey(base)
+  assert.is(cacheKey(base), key)
+  assert.not.ok(cacheKey({ ...base, scope: 'x' }) === key)
+  assert.not.ok(cacheKey({ ...base, account: 'a' }) === key)
+  assert.not.ok(cacheKey({ ...base, configDir: '/tmp/op' }) === key)
+  assert.not.ok(cacheKey({ ...base, opPath: '/bin/echo' }) === key)
+  assert.not.ok(cacheKey({ ...base, reference: 'op://vault/item/other' }) === key)
+  assert.is(effectiveAccount('explicit', { OP_ACCOUNT: 'env' }), 'explicit')
+  assert.is(effectiveAccount(undefined, { OP_ACCOUNT: 'env' }), 'env')
+  assert.is(effectiveAccount(undefined, { OP_ACCOUNT: '' }), '')
+})
+
+test('SecretCache expires, does not extend on hit, evicts LRU, and clears by scope', () => {
+  let now = 1000
+  const cache = new SecretCache({ maxEntries: 2, now: () => now })
+  cache.set('a', 'A', { ttlSeconds: 1, scope: 'one' })
+  assert.is(cache.get('a'), 'A')
+  now = 2500
+  assert.is(cache.get('a'), undefined)
+
+  now = 1000
+  cache.set('a', 'A', { ttlSeconds: 1, scope: 'one' })
+  now = 1500
+  assert.is(cache.get('a'), 'A')
+  now = 2100
+  assert.is(cache.get('a'), undefined)
+
+  now = 1000
+  cache.set('a', 'A', { ttlSeconds: 10, scope: 'one' })
+  cache.set('b', 'B', { ttlSeconds: 10, scope: 'two' })
+  assert.is(cache.get('a'), 'A')
+  cache.set('c', 'C', { ttlSeconds: 10, scope: 'two' })
+  assert.is(cache.get('b'), undefined)
+  assert.is(cache.countByScope('two'), 1)
+  assert.is(cache.clearScope('two'), 1)
+  assert.is(cache.countByScope('one'), 1)
+  assert.is(cache.isEmpty(), false)
+  assert.is(cache.clear(), 1)
+  assert.is(cache.isEmpty(), true)
+})
+
+test('protocol round-trips and validates shapes', () => {
+  const req = { type: 'set', key: 'k', value: 'multi\nline', scope: 'user', ttlSeconds: 30 }
+  assert.equal(validateRequest(decode(encode(req))), req)
+  try {
+    validateRequest({ type: 'bogus' })
+    assert.unreachable('should reject')
+  } catch (err) {
+    assert.match(err.message, /Unknown/)
+  }
+})
+
+test('config precedence is flags, env, file, defaults', () => {
+  resetConfigCache()
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'op-cache-config-'))
+  const file = path.join(dir, 'config.json')
+  fs.writeFileSync(file, JSON.stringify({ ttl_seconds: 10, max_entries: 10, op_path: 'file-op' }))
+  const env = { OP_CACHE_TTL_SECONDS: '20', OP_CACHE_OP_PATH: 'env-op', TMPDIR: dir }
+  const result = resolveConfig({ configPath: file, ttlSeconds: '30s' }, { env, useCache: false })
+  assert.is(result.config.ttl_seconds, 30)
+  assert.is(result.config.op_path, 'env-op')
+  assert.is(result.config.max_entries, 10)
+  assert.is(result.exists, true)
+})
+
+test('config handles absent file and invalid JSON', () => {
+  resetConfigCache()
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'op-cache-config-'))
+  const missing = path.join(dir, 'missing.json')
+  assert.ok(resolveConfig({ configPath: missing }, { env: { TMPDIR: dir }, useCache: false }).config.socket_path.includes('op-cache-'))
+  const bad = path.join(dir, 'bad.json')
+  fs.writeFileSync(bad, '{')
+  try {
+    resolveConfig({ configPath: bad }, { env: { TMPDIR: dir }, useCache: false })
+    assert.unreachable('should reject')
+  } catch (err) {
+    assert.match(err.message, /Invalid op-cache config/)
+    assert.match(err.message, /bad\.json/)
+  }
+})
+
+test('op stderr translation reports missing fields as not found', () => {
+  const err = translateError(
+    "[ERROR] could not read secret 'op://vault/item/password': item 'vault/item' does not have a field 'password'",
+    'op://vault/item/password'
+  )
+  assert.match(err.message, /field could not be found/)
+  assert.match(err.message, /op:\/\/vault\/item\/password/)
+})
+
+test.run()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@cdktf/hcl2json':
         specifier: ^0.21.0
         version: 0.21.0
+      '@davidwells/op-cache':
+        specifier: workspace:^
+        version: link:../op-cache
       '@types/node':
         specifier: ^24.10.1
         version: 24.13.2
@@ -108,6 +111,12 @@ importers:
       minimist:
         specifier: ^1.2.8
         version: 1.2.8
+    devDependencies:
+      uvu:
+        specifier: ^0.5.6
+        version: 0.5.6
+
+  packages/op-cache:
     devDependencies:
       uvu:
         specifier: ^0.5.6


### PR DESCRIPTION
## Summary

Ships `@davidwells/op-cache` 0.1.0 plus all-syntax caching in the configorama onepassword plugin. Every supported `${op...}` syntax flavor — aliases, item names/IDs, private links, explicit fields, inferred fields, structured note key paths, and direct `op://` refs — now reuses the in-memory daemon cache across fresh Node processes, so repeated agent commands (`configx .env -- node script.js`) stop re-prompting 1Password within the TTL.

Specs: `docs/plans/op-cache-js-package.md` (v1) and `docs/plans/op-cache-all-onepassword-syntax.md` (this feature). Beads: `configorama-dpes` (v1) and `configorama-xfif` (all-syntax), all closed.

## Design highlights

- **Final resolved values only, never item JSON** — the daemon stays a scalar secret cache; a cached entry is exactly the string a variable resolved to
- **`getOrSet(cacheRef, producer, opts)`** advanced integration API: caller-supplied miss producers, `validateCached` hook (reject → recompute → overwrite), same `OP_CACHE_DISABLED`/win32/fallback ladder as `read`, once-per-process warnings
- **Plugin-side `{value, fieldName}` envelope** keeps `opReferences` audit metadata byte-identical between miss and hit runs; op-cache stays string-in/string-out
- **Canonical NUL-joined synthetic cache refs** (`configorama-op://v1/<sha256>`); private links reduced to item/vault IDs, raw URLs never leave the client
- Fail-closed by default when a configured cache breaks; `fallbackToOp: true` opts into degradation

## Testing

- op-cache package: 40 tests across 4 suites (incl. 17 for getOrSet)
- Plugin: 17 op-cache integration tests + cross-process regression proving the second process resolves all four syntax families with **zero** op invocations
- Existing 33-test plugin suite passes unchanged with no cache configured
- Full `pnpm -r test`, `npm run typecheck`, and pack-smoke (tarball install, bin, zero deps) all green
- Manual QA against real 1Password: 1 miss + 3 hits on repeated `op-cache read`, TTL expiry re-fetches correctly

## Fixes found along the way

- Daemon signal-listener leak on close
- Misleading ENOENT for over-long Unix socket paths (now a clear error)
- Racy fake-op test counter (atomic O_APPEND)

## Publish plan

After merge: `lerna publish` from master picks up `@davidwells/op-cache` 0.1.0 (first publish) and configorama (plugin changes, feat bump). configx unchanged.